### PR TITLE
override problematic blockquote style inherited from Atom styles

### DIFF
--- a/stylesheets/asciidoc-preview.less
+++ b/stylesheets/asciidoc-preview.less
@@ -395,3 +395,8 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 .literalblock > .content > pre, .listingblock > .content > pre { -webkit-border-radius: 0; border-radius: 0; }
 
 }
+
+/* Atom style overrides */
+.asciidoc-preview {
+blockquote:before,blockquote:after { content: none; }
+}


### PR DESCRIPTION
Fixes the problem where the first word in the abstract (in a book doctype) is slightly indented.
