### PR TITLE
Add render on save only configuration

### DIFF
--- a/keymaps/asciidoc-preview.cson
+++ b/keymaps/asciidoc-preview.cson
@@ -1,5 +1,6 @@
 '.workspace':
   'ctrl-A': 'asciidoc-preview:toggle'
+  'ctrl-alt-a': 'asciidoc-preview:toggle-render-on-save-only'
 
 '.asciidoc-preview':
   'cmd-+': 'asciidoc-preview:zoom-in'

--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -95,12 +95,16 @@ class AsciiDocPreviewView extends ScrollView
       if pane? and pane isnt atom.workspace.getActivePane()
         pane.activateItem(this)
 
+    renderOnChange = =>
+      saveOnly = atom.config.get('asciidoc-preview.renderOnSaveOnly')
+      changeHandler() if !saveOnly
+
     if @file?
       @subscribe(@file, 'contents-changed', changeHandler)
     else if @editor?
-      @subscribe(@editor.getBuffer(), 'contents-modified', changeHandler)
+      @subscribe(@editor.getBuffer(), 'contents-modified', renderOnChange)
+      @subscribe(@editor.getBuffer(), 'saved', changeHandler)
       @subscribe @editor, 'path-changed', => @trigger 'title-changed'
-
 
     @subscribe atom.config.observe 'asciidoc-preview.showTitle', callNow: false, changeHandler
     @subscribe atom.config.observe 'asciidoc-preview.safeMode', callNow: false, changeHandler

--- a/test.asciidoc
+++ b/test.asciidoc
@@ -45,7 +45,7 @@ NOTE: Items marked with TODO are either not yet supported or a work in progress.
 
 .Inline markup
 * single quotes around a phrase place 'emphasis'
-* astericks around a phrase make the text de de je pense que ca marche *bold*
+* a fsdf sdd sdf s sd round a phrase make the text de de je pense que ca marche *bold*
 * double astericks around one or more **l**etters in a word make those letters bold
 * double underscore arounfgdgdfgfdgddfgdgdfgdgdfgdfgddfgdfgfdgd a __sub__string in a word emphasizes that substring
 * use carrots around characters to make them ^super^script


### PR DESCRIPTION
You can switch mode with shortcut `ctrl + alt + a`
Default mode is render on change

Add a checkbox in settings : 
![capture du 2014-05-22 01 30 24](https://cloud.githubusercontent.com/assets/2006548/3048054/f1e562c4-e13f-11e3-9216-855968097338.png)

Add information on the active mode in the bottom toolbar : 
![capture du 2014-05-22 01 31 16](https://cloud.githubusercontent.com/assets/2006548/3048061/13584fac-e140-11e3-870b-41d81d16c82f.png)
