### PR TITLE
clean up render mode in status bar

### DIFF
--- a/lib/asciidoc-preview.coffee
+++ b/lib/asciidoc-preview.coffee
@@ -107,10 +107,10 @@ module.exports =
         previousActivePane.activate()
 
   changeRenderMode: ->
+    atom.workspaceView.find('#asciidoc-changemode')?.remove()
     return unless @checkFile()?
 
     saveOnly = atom.config.get('asciidoc-preview.renderOnSaveOnly')
-    atom.workspaceView.find('#asciidoc-changemode')?.remove()
     if saveOnly
       atom.workspaceView.statusBar?.appendLeft("<span id='asciidoc-changemode'>Render on save<span>")
     else


### PR DESCRIPTION
"Render on change" or "Render on save" 
should only be shown in the status bar of a relevant file.
