### PR TITLE
Changed autocomplete dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "underscore-plus": "1.x",
     "wrench": "1.5.x",
     "mustache": "0.8.2",
-    "autocomplete-plus": "git://github.com/saschagehlich/autocomplete-plus.git",
+    "autocomplete-plus": "https://github.com/atom-community/autocomplete-plus.git",
     "fuzzaldrin": "~1.0.0"
   }
 }


### PR DESCRIPTION
Having a dependency using a git protocol reference does not work nicely
with firewall that blocks anything except http and https connections.