### PR TITLE
fix include::

### DIFF
--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -13,7 +13,7 @@ module.exports = (text, attributes, filePath) ->
   folder = path.dirname(filePath)
   Opal.ENV['$[]=']("PWD", path.dirname(attributes.opalPwd))
   opts = Opal.hash2(['base_dir', 'safe', 'doctype', 'attributes'], {
-      'base_dir': 'file://'.concat(folder),
+      'base_dir': folder,
       'safe': attributes.safemode,
       'doctype': attributes.doctype,
       'attributes': concatAttributes


### PR DESCRIPTION
when `Safe Mode` is not `secure` `include::doc.adoc[]` does not work, it prints `Unresolved directive in <stdin> - include::doc.adoc[]`

this patch fixes it.
