### PR TITLE
fix name of default toc config setting

### DIFF
--- a/lib/asciidoc-preview.coffee
+++ b/lib/asciidoc-preview.coffee
@@ -14,7 +14,7 @@ module.exports =
     compatMode: true
     showTitle: true
     safeMode: 'secure'
-    showTableOfContent: true
+    showToc: true
     showNumberedHeadings: true
     renderOnSaveOnly: false
     defaultAttributes: 'platform=opal platform-opal env=browser env-browser'


### PR DESCRIPTION
We are seeing a duplicate entry in the config settings for the toc.

* Show Table of Content
* Show Toc

This patch removes the first entry, which is unused.