### PR TITLE
improved toc configuration using a select option instead of a toogle

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -130,7 +130,7 @@ class AsciiDocPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'asciidoc-preview.compatMode', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.safeMode', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.defaultAttributes', changeHandler
-    @disposables.add atom.config.onDidChange 'asciidoc-preview.showToc', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.tocType', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.showNumberedHeadings', changeHandler
 
   renderAsciiDoc: ->

--- a/lib/asciidoc-preview.coffee
+++ b/lib/asciidoc-preview.coffee
@@ -16,9 +16,11 @@ module.exports =
     safeMode:
       type: 'string'
       default: 'safe'
-    showToc:
-      type: 'boolean'
-      default: true
+    tocType:
+      title: 'Show Table of Contents'
+      type: 'string'
+      default: 'preamble'
+      enum: ['none','preamble','macro']
     showNumberedHeadings:
       type: 'boolean'
       default: true
@@ -52,9 +54,15 @@ module.exports =
       'asciidoc-preview:toggle-compat-mode': ->
         keyPath = 'asciidoc-preview.compatMode'
         atom.config.set(keyPath, !atom.config.get(keyPath))
-      'asciidoc-preview:toggle-show-toc': ->
-        keyPath = 'asciidoc-preview.showToc'
-        atom.config.set(keyPath, !atom.config.get(keyPath))
+      'asciidoc-preview:set-toc-none': ->
+        keyPath = 'asciidoc-preview.tocType'
+        atom.config.set(keyPath, 'none')
+      'asciidoc-preview:set-toc-preamble': ->
+        keyPath = 'asciidoc-preview.tocType'
+        atom.config.set(keyPath, 'preamble')
+      'asciidoc-preview:set-toc-macro': ->
+        keyPath = 'asciidoc-preview.tocType'
+        atom.config.set(keyPath, 'macro')
       'asciidoc-preview:toggle-show-numbered-headings': ->
         keyPath = 'asciidoc-preview.showNumberedHeadings'
         atom.config.set(keyPath, !atom.config.get(keyPath))

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -12,12 +12,12 @@ highlighter = null
 
 exports.toHtml = (text, filePath, callback) ->
   return unless atom.config.get('asciidoc-preview.defaultAttributes')?
-  attributes= {
+  attributes = {
     defaultAttributes: atom.config.get('asciidoc-preview.defaultAttributes'),
     numbered: if atom.config.get('asciidoc-preview.showNumberedHeadings') then 'numbered' else 'numbered!',
     showtitle: if atom.config.get('asciidoc-preview.showTitle') then 'showtitle' else 'showtitle!',
     compatmode: if atom.config.get('asciidoc-preview.compatMode') then 'compat-mode=@' else '',
-    showtoc: if atom.config.get('asciidoc-preview.showToc')  then 'toc=preamble toc2!' else 'toc! toc2!',
+    toctype: calculateTocType(),
     safemode: atom.config.get('asciidoc-preview.safeMode') or 'safe',
     doctype: atom.config.get('asciidoc-preview.docType') or "article",
     opalPwd: window.location.href
@@ -38,6 +38,16 @@ exports.toText = (text, filePath, callback) ->
     else
       string = $(document.createElement('div')).append(html)[0].innerHTML
       callback(error, string)
+
+calculateTocType = () ->
+  if (atom.config.get('asciidoc-preview.tocType') == 'none')
+    return ""
+  # NOTE: 'auto' (blank option in asciidoctor) is currently not supported but
+  # this section is left as a reminder of the expected behaviour
+  else if (atom.config.get('asciidoc-preview.tocType') == 'auto')
+    return "toc! toc2!"
+  else
+    return "toc=#{atom.config.get('asciidoc-preview.tocType')} toc2!"
 
 sanitize = (html) ->
   o = cheerio.load(html)

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -9,7 +9,8 @@ module.exports = (text, attributes, filePath) ->
                     .concat(attributes.numbered).concat(' ')
                     .concat(attributes.showtitle).concat(' ')
                     .concat(attributes.compatmode).concat(' ')
-                    .concat(attributes.showtoc)
+                    .concat(attributes.toctype)
+
   folder = path.dirname(filePath)
   Opal.ENV['$[]=']("PWD", path.dirname(attributes.opalPwd))
   opts = Opal.hash2(['base_dir', 'safe', 'doctype', 'attributes'], {

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -14,7 +14,14 @@
     {label: 'Copy', command: 'core:copy'}
     {label: 'Save As HTML\u2026', command: 'core:save-as'}
     {label: 'Toggle Document Title', command: 'asciidoc-preview:toggle-show-title'}
-    {label: 'Toggle Table of Contents', command: 'asciidoc-preview:toggle-show-toc'}
+    {
+      label: 'Show Table of Contents'
+      submenu: [
+        {label: 'none', command: 'asciidoc-preview:set-toc-none'}
+        {label: 'preamble', command: 'asciidoc-preview:set-toc-preamble'}
+        {label: 'macro', command: 'asciidoc-preview:set-toc-macro'}
+      ]
+    }
     {label: 'Toggle Heading Numbers', command: 'asciidoc-preview:toggle-show-numbered-headings'}
     {label: 'Toggle Compat Mode', command: 'asciidoc-preview:toggle-compat-mode'}
   ]


### PR DESCRIPTION
Related to issue #99 this PR makes it easier to set the currently available `top` options: none (blank), preamble and macro.

This PR:
* Changes the checkbox configuration in the settings panel by a multi-select option.
![settings_menu](https://cloud.githubusercontent.com/assets/5781153/8893576/df9e241c-3395-11e5-8db4-ec75bae12cb7.png)

* Replaces the context menu with a sub-menu with the different options.
![context_menu](https://cloud.githubusercontent.com/assets/5781153/8893567/74660548-3395-11e5-844c-361ad964adfc.png)

Any comments will be greatly appreciated, I’m not into front-end/web techs and almost everything here is new to me.