### PR TITLE
add skip-front-matter to default attributes

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -131,6 +131,7 @@ class AsciiDocPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'asciidoc-preview.safeMode', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.defaultAttributes', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.tocType', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.skipFrontMatter', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.showNumberedHeadings', changeHandler
 
   renderAsciiDoc: ->

--- a/lib/asciidoc-preview.coffee
+++ b/lib/asciidoc-preview.coffee
@@ -21,6 +21,9 @@ module.exports =
       type: 'string'
       default: 'preamble'
       enum: ['none','preamble','macro']
+    skipFrontMatter:
+      type: 'boolean'
+      default: true
     showNumberedHeadings:
       type: 'boolean'
       default: true
@@ -63,6 +66,9 @@ module.exports =
       'asciidoc-preview:set-toc-macro': ->
         keyPath = 'asciidoc-preview.tocType'
         atom.config.set(keyPath, 'macro')
+      'asciidoc-preview:toggle-skip-front-matter': ->
+        keyPath = 'asciidoc-preview.skipFrontMatter'
+        atom.config.set(keyPath, !atom.config.get(keyPath))
       'asciidoc-preview:toggle-show-numbered-headings': ->
         keyPath = 'asciidoc-preview.showNumberedHeadings'
         atom.config.set(keyPath, !atom.config.get(keyPath))

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -15,6 +15,7 @@ exports.toHtml = (text, filePath, callback) ->
   attributes = {
     defaultAttributes: atom.config.get('asciidoc-preview.defaultAttributes'),
     numbered: if atom.config.get('asciidoc-preview.showNumberedHeadings') then 'numbered' else 'numbered!',
+    skipfrontmatter: if atom.config.get('asciidoc-preview.skipFrontMatter') then 'skip-front-matter' else '',
     showtitle: if atom.config.get('asciidoc-preview.showTitle') then 'showtitle' else 'showtitle!',
     compatmode: if atom.config.get('asciidoc-preview.compatMode') then 'compat-mode=@' else '',
     toctype: calculateTocType(),

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -7,6 +7,7 @@ module.exports = (text, attributes, filePath) ->
 
   concatAttributes = attributes.defaultAttributes.concat(' icons=font@ ')
                     .concat(attributes.numbered).concat(' ')
+                    .concat(attributes.skipfrontmatter).concat(' ')
                     .concat(attributes.showtitle).concat(' ')
                     .concat(attributes.compatmode).concat(' ')
                     .concat(attributes.toctype)

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -22,6 +22,7 @@
         {label: 'macro', command: 'asciidoc-preview:set-toc-macro'}
       ]
     }
+    {label: 'Toggle Front Matter', command: 'asciidoc-preview:toggle-skip-front-matter'}
     {label: 'Toggle Heading Numbers', command: 'asciidoc-preview:toggle-show-numbered-headings'}
     {label: 'Toggle Compat Mode', command: 'asciidoc-preview:toggle-compat-mode'}
   ]


### PR DESCRIPTION
Files with frontmatter mess up the preview. I guess in most cases one can simply ignore it.