### PR TITLE
Resolves #125, escape ': . [ ] , ( )' characters in links

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -173,6 +173,8 @@ class AsciiDocPreviewView extends ScrollView
           link.on 'mouseleave', (e) ->
             $(divLink).empty()
         continue if not hrefLink.match(/^#/)
+        # Because jQuery uses CSS syntax for selecting elements, some characters are interpreted as CSS notation.
+        # In order to tell jQuery to treat these characters literally rather than as CSS notation, they must be "escaped" by placing two backslashes in front of them.
         if target = $(hrefLink.replace(/(\/|:|\.|\[|\]|,|\)|\()/g, '\\$1'))
           continue if not target.offset()
           # TODO Use tab height variable instead of 43

--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -173,7 +173,7 @@ class AsciiDocPreviewView extends ScrollView
           link.on 'mouseleave', (e) ->
             $(divLink).empty()
         continue if not hrefLink.match(/^#/)
-        if target = $(hrefLink)
+        if target = $(hrefLink.replace(/(\/|:|\.|\[|\]|,|\)|\()/g, '\\$1'))
           continue if not target.offset()
           # TODO Use tab height variable instead of 43
           top = target.offset().top - 43


### PR DESCRIPTION
Resolves #117 #115 #123 #125