### PR TITLE
feat: more user friendly settings

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -129,7 +129,7 @@ class AsciiDocPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'asciidoc-preview.safeMode', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.defaultAttributes', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.tocType', changeHandler
-    @disposables.add atom.config.onDidChange 'asciidoc-preview.skipFrontMatter', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.frontMatter', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.showNumberedHeadings', changeHandler
 
   renderAsciiDoc: ->

--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -104,8 +104,7 @@ class AsciiDocPreviewView extends ScrollView
     changeHandler = =>
       @renderAsciiDoc()
 
-      # TODO: Remove paneForURI call when ::paneForItem is released
-      pane = atom.workspace.paneForItem?(this) ? atom.workspace.paneForURI(@getURI())
+      pane = atom.workspace.paneForItem(this)
       if pane? and pane isnt atom.workspace.getActivePane()
         pane.activateItem(this)
 

--- a/lib/extension-helper.coffee
+++ b/lib/extension-helper.coffee
@@ -1,3 +1,4 @@
+# this list is limited by the support of Highlights
 scopesByFenceName =
   'sh': 'source.shell'
   'asciidoc': 'source.asciidoc'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,7 @@ module.exports =
       title: 'Compatibility mode (AsciiDoc Python)'
       type: 'boolean'
       default: false
+      order: 1
     forceExperimental:
       title: 'Force enable experimental extensions'
       description: '''
@@ -19,6 +20,7 @@ module.exports =
         '''
       type: 'boolean'
       default: false
+      order: 2
     showTitle:
       description: '''
         If set, displays an embedded document’s title.
@@ -27,6 +29,7 @@ module.exports =
         '''
       type: 'boolean'
       default: true
+      order: 3
     safeMode:
       description: '''
         Set safe mode level: `unsafe`, `safe`, `server` or `secure`.
@@ -37,27 +40,33 @@ module.exports =
         '''
       type: 'string'
       default: 'safe'
+      order: 4
     tocType:
       title: 'Show Table of Contents'
       type: 'string'
       default: 'preamble'
       enum: ['none', 'preamble', 'macro']
+      order: 5
     frontMatter:
       description: '''
         If set, consume YAML-style front matter at the top of the document and store it in the front-matter attribute.
         '''
       type: 'boolean'
       default: false
+      order: 6
     showNumberedHeadings:
       description: 'Auto-number section titles.'
       type: 'boolean'
       default: true
+      order: 7
     renderOnSaveOnly:
       type: 'boolean'
       default: false
+      order: 8
     defaultAttributes:
       type: 'string'
       default: 'platform=opal platform-opal env=browser env-browser source-highlighter=highlight.js data-uri!'
+      order: 9
     grammars:
       type: 'array'
       default: [
@@ -65,6 +74,7 @@ module.exports =
         'text.plain'
         'text.plain.null-grammar'
       ]
+      order: 10
 
   activate: ->
     atom.commands.add 'atom-workspace',

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,12 +7,34 @@ module.exports =
 
   config:
     compatMode:
+      title: 'Compatibility mode (AsciiDoc Python)'
       type: 'boolean'
-      default: true
+      default: false
+    forceExperimental:
+      title: 'Force enable experimental extensions'
+      description: '''
+        The features behind this attribute are subject to change and may even be removed in a future version.
+
+        Currently enables the UI macros (`button`, `menu` and `kbd`).
+        '''
+      type: 'boolean'
+      default: false
     showTitle:
+      description: '''
+        If set, displays an embedded document’s title.
+
+        Mutually exclusive with the notitle attribute.
+        '''
       type: 'boolean'
       default: true
     safeMode:
+      description: '''
+        Set safe mode level: `unsafe`, `safe`, `server` or `secure`.
+
+        Disables potentially dangerous macros in source files, such as `include::[]`.
+
+        If not set, the safe mode level defaults to unsafe when Asciidoctor is invoked using this script.
+        '''
       type: 'string'
       default: 'safe'
     tocType:
@@ -20,10 +42,14 @@ module.exports =
       type: 'string'
       default: 'preamble'
       enum: ['none', 'preamble', 'macro']
-    skipFrontMatter:
+    frontMatter:
+      description: '''
+        If set, consume YAML-style front matter at the top of the document and store it in the front-matter attribute.
+        '''
       type: 'boolean'
-      default: true
+      default: false
     showNumberedHeadings:
+      description: 'Auto-number section titles.'
       type: 'boolean'
       default: true
     renderOnSaveOnly:

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -43,7 +43,11 @@ module.exports =
       enum: ['unsafe', 'safe', 'server', 'secure']
       order: 4
     tocType:
-      title: 'Show Table of Contents'
+      title: 'Force show Table of Contents'
+      description: '''
+        Force to show TOC: override `:toc:` attribute defined in documents.<br>
+        Choose `none` to define manually the `:toc:` attribute in documents.
+        '''
       type: 'string'
       default: 'preamble'
       enum: ['none', 'preamble', 'macro']
@@ -92,14 +96,11 @@ module.exports =
         keyPath = 'asciidoc-preview.compatMode'
         atom.config.set(keyPath, not atom.config.get(keyPath))
       'asciidoc-preview:set-toc-none': ->
-        keyPath = 'asciidoc-preview.tocType'
-        atom.config.set(keyPath, 'none')
+        atom.config.set('asciidoc-preview.tocType', 'none')
       'asciidoc-preview:set-toc-preamble': ->
-        keyPath = 'asciidoc-preview.tocType'
-        atom.config.set(keyPath, 'preamble')
+        atom.config.set('asciidoc-preview.tocType', 'preamble')
       'asciidoc-preview:set-toc-macro': ->
-        keyPath = 'asciidoc-preview.tocType'
-        atom.config.set(keyPath, 'macro')
+        atom.config.set('asciidoc-preview.tocType', 'macro')
       'asciidoc-preview:toggle-skip-front-matter': ->
         keyPath = 'asciidoc-preview.skipFrontMatter'
         atom.config.set(keyPath, not atom.config.get(keyPath))

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -36,10 +36,11 @@ module.exports =
 
         Disables potentially dangerous macros in source files, such as `include::[]`.
 
-        If not set, the safe mode level defaults to unsafe when Asciidoctor is invoked using this script.
+        http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely
         '''
       type: 'string'
       default: 'safe'
+      enum: ['unsafe', 'safe', 'server', 'secure']
       order: 4
     tocType:
       title: 'Show Table of Contents'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -32,11 +32,10 @@ module.exports =
       order: 3
     safeMode:
       description: '''
-        Set safe mode level: `unsafe`, `safe`, `server` or `secure`.
-
-        Disables potentially dangerous macros in source files, such as `include::[]`.
-
-        http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely
+        Set safe mode level: `unsafe`, `safe`, `server` or `secure`.<br>
+        Disables potentially dangerous macros in source files, such as `include::[]`.<br>
+        Set safe mode level to `safe` to enable include macros, but restricts access to ancestor paths of source file.<br>
+        http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely<br>
         '''
       type: 'string'
       default: 'safe'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -40,14 +40,15 @@ exports.toText = (text, filePath, callback) ->
       callback(error, string)
 
 calculateTocType = ->
-  if atom.config.get('asciidoc-preview.tocType') is 'none'
+  tocType = atom.config.get 'asciidoc-preview.tocType'
+  if tocType is 'none'
     return ''
   # NOTE: 'auto' (blank option in asciidoctor) is currently not supported but
   # this section is left as a reminder of the expected behaviour
-  else if atom.config.get('asciidoc-preview.tocType') is 'auto'
+  else if tocType is 'auto'
     return 'toc! toc2!'
   else
-    return "toc=#{atom.config.get('asciidoc-preview.tocType')} toc2!"
+    return "toc=#{tocType} toc2!"
 
 sanitize = (html) ->
   o = cheerio.load(html)

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -14,9 +14,10 @@ exports.toHtml = (text, filePath, callback) ->
   attributes =
     defaultAttributes: atom.config.get('asciidoc-preview.defaultAttributes')
     numbered: if atom.config.get('asciidoc-preview.showNumberedHeadings') then 'numbered' else 'numbered!'
-    skipfrontmatter: if atom.config.get('asciidoc-preview.skipFrontMatter') then 'skip-front-matter' else ''
+    skipfrontmatter: if atom.config.get('asciidoc-preview.frontMatter') then '' else 'skip-front-matter'
     showtitle: if atom.config.get('asciidoc-preview.showTitle') then 'showtitle' else 'showtitle!'
     compatmode: if atom.config.get('asciidoc-preview.compatMode') then 'compat-mode=@' else ''
+    forceExperimental: if atom.config.get('asciidoc-preview.forceExperimental') then 'experimental' else ''
     toctype: calculateTocType()
     safemode: atom.config.get('asciidoc-preview.safeMode') or 'safe'
     doctype: atom.config.get('asciidoc-preview.docType') or 'article'

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -25,7 +25,7 @@ module.exports = (text, attributes, filePath) ->
     base_dir: folder
     safe: attributes.safemode
     doctype: attributes.doctype
-    attributes: concatAttributes
+    attributes: concatAttributes.trim()
 
   html = Asciidoctor.$convert text, options
   callback(html)

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -4,22 +4,28 @@ Opal = ajs.Opal
 path = require 'path'
 
 module.exports = (text, attributes, filePath) ->
+  callback = @async()
 
-  concatAttributes = attributes.defaultAttributes.concat(' icons=font@ ')
-                    .concat(attributes.numbered).concat(' ')
-                    .concat(attributes.skipfrontmatter).concat(' ')
-                    .concat(attributes.showtitle).concat(' ')
-                    .concat(attributes.compatmode).concat(' ')
-                    .concat(attributes.toctype)
+  concatAttributes = [
+    attributes.defaultAttributes
+    'icons=font@'
+    attributes.numbered
+    attributes.skipfrontmatter
+    attributes.showtitle
+    attributes.compatmode
+    attributes.toctype
+    attributes.forceExperimental
+  ].join ' '
 
   folder = path.dirname(filePath)
+
   Opal.ENV['$[]=']('PWD', path.dirname(attributes.opalPwd))
-  opts = Opal.hash
+
+  options = Opal.hash
     base_dir: folder
     safe: attributes.safemode
     doctype: attributes.doctype
     attributes: concatAttributes
 
-  html = Asciidoctor.$convert(text, opts)
-  callback = @async()
+  html = Asciidoctor.$convert text, options
   callback(html)

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -16,7 +16,7 @@ menu: [
   ,
     label: 'Toggle Document Title', command: 'asciidoc-preview:toggle-show-title'
   ,
-    label: 'Show Table of Contents'
+    label: 'Force show Table of Contents'
     submenu: [
       label: 'none', command: 'asciidoc-preview:set-toc-none'
     ,


### PR DESCRIPTION
- set compat-mode to false by default.
- add `force experimental`
- `skipFrontMatter` become `frontMatter` : positive expression always better!
- add descriptions for options
- ordering options
- use enum for the safe mode definition
- change 'Show Table of Content' to 'Force show Table of Content', add explanations

![capture du 2016-05-29 20-21-53](https://cloud.githubusercontent.com/assets/5674651/15635291/02685ba6-25db-11e6-800d-86e13c67b715.png)

