### PR TITLE
feature: section numbering

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -130,7 +130,7 @@ class AsciiDocPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'asciidoc-preview.defaultAttributes', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.tocType', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.frontMatter', changeHandler
-    @disposables.add atom.config.onDidChange 'asciidoc-preview.showNumberedHeadings', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.sectionNumbering', changeHandler
 
   renderAsciiDoc: ->
     @showLoading() unless @loaded

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,11 +33,16 @@ module.exports =
         atom.config.set('asciidoc-preview.tocType', 'preamble')
       'asciidoc-preview:set-toc-macro': ->
         atom.config.set('asciidoc-preview.tocType', 'macro')
+      'asciidoc-preview:set-section-numbering-soft-on': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'soft-on')
+      'asciidoc-preview:set-section-numbering-always-on': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'always-on')
+      'asciidoc-preview:set-section-numbering-always-off': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'always-off')
+      'asciidoc-preview:set-section-numbering-let-document-decide': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'let-document-decide')
       'asciidoc-preview:toggle-skip-front-matter': ->
         keyPath = 'asciidoc-preview.skipFrontMatter'
-        atom.config.set(keyPath, not atom.config.get(keyPath))
-      'asciidoc-preview:toggle-show-numbered-headings': ->
-        keyPath = 'asciidoc-preview.showNumberedHeadings'
         atom.config.set(keyPath, not atom.config.get(keyPath))
       'asciidoc-preview:toggle-render-on-save-only': ->
         keyPath = 'asciidoc-preview.renderOnSaveOnly'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -15,7 +15,7 @@ exports.toHtml = (text='', filePath, callback) ->
   return unless atom.config.get('asciidoc-preview.defaultAttributes')?
   attributes =
     defaultAttributes: atom.config.get('asciidoc-preview.defaultAttributes')
-    numbered: if atom.config.get('asciidoc-preview.showNumberedHeadings') then 'numbered' else 'numbered!'
+    numbered: sectionNumbering()
     skipfrontmatter: if atom.config.get('asciidoc-preview.frontMatter') then '' else 'skip-front-matter'
     showtitle: if atom.config.get('asciidoc-preview.showTitle') then 'showtitle' else 'showtitle!'
     compatmode: if atom.config.get('asciidoc-preview.compatMode') then 'compat-mode=@' else ''
@@ -51,6 +51,17 @@ calculateTocType = ->
     return 'toc! toc2!'
   else
     return "toc=#{tocType} toc2!"
+
+sectionNumbering = ->
+  numberedOption = atom.config.get('asciidoc-preview.sectionNumbering')
+  if numberedOption is 'always-on'
+    'sectnums'
+  else if numberedOption is 'always-off'
+    'sectnums!'
+  else if numberedOption is 'soft-on'
+    'sectnums=@'
+  else
+    ''
 
 sanitize = (html) ->
   o = cheerio.load(html)

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -1,9 +1,35 @@
 menu: [
   label: 'Packages'
   submenu: [
-    label: 'AsciiDoc'
+    label: 'AsciiDoc Preview'
     submenu: [
       label: 'Toggle Preview', command: 'asciidoc-preview:toggle'
+    ,
+      label: 'Always show Table of Contents'
+      submenu: [
+        label: 'none', command: 'asciidoc-preview:set-toc-none'
+      ,
+        label: 'preamble', command: 'asciidoc-preview:set-toc-preamble'
+      ,
+        label: 'macro', command: 'asciidoc-preview:set-toc-macro'
+      ]
+    ,
+      label: 'Section Numbering'
+      submenu: [
+        label: 'Soft on', command: 'asciidoc-preview:set-section-numbering-soft-on'
+      ,
+        label: 'Always on', command: 'asciidoc-preview:set-section-numbering-always-on'
+      ,
+        label: 'Always off', command: 'asciidoc-preview:set-section-numbering-always-off'
+      ,
+        label: 'Let the document decide', command: 'asciidoc-preview:set-section-numbering-let-document-decide'
+      ]
+    ,
+      label: 'Toggle Document Title', command: 'asciidoc-preview:toggle-show-title'
+    ,
+      label: 'Toggle Front Matter', command: 'asciidoc-preview:toggle-skip-front-matter'
+    ,
+      label: 'Toggle Compat Mode', command: 'asciidoc-preview:toggle-compat-mode'
     ]
   ]
 ]

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -27,7 +27,16 @@ menu: [
   ,
     label: 'Toggle Front Matter', command: 'asciidoc-preview:toggle-skip-front-matter'
   ,
-    label: 'Toggle Heading Numbers', command: 'asciidoc-preview:toggle-show-numbered-headings'
+    label: 'Section Numbering'
+    submenu: [
+      label: 'Soft on', command: 'asciidoc-preview:set-section-numbering-soft-on'
+    ,
+      label: 'Always on', command: 'asciidoc-preview:set-section-numbering-always-on'
+    ,
+      label: 'Always off', command: 'asciidoc-preview:set-section-numbering-always-off'
+    ,
+      label: 'Let the document decide', command: 'asciidoc-preview:set-section-numbering-let-document-decide'
+    ]
   ,
     label: 'Toggle Compat Mode', command: 'asciidoc-preview:toggle-compat-mode'
   ]

--- a/package.json
+++ b/package.json
@@ -77,10 +77,16 @@
       "default": false,
       "order": 6
     },
-    "showNumberedHeadings": {
-      "description": "Auto-number section titles.",
-      "type": "boolean",
-      "default": true,
+    "sectionNumbering": {
+      "description": "Auto-number section titles.<br>http://asciidoctor.org/docs/user-manual/#numbering",
+      "type": "string",
+      "default": "soft-on",
+      "enum": [
+        "soft-on",
+        "always-on",
+        "always-off",
+        "let-document-decide"
+      ],
       "order": 7
     },
     "renderOnSaveOnly": {


### PR DESCRIPTION
# Description

Rethink the section numbering option:


- soft on: Turn it on unless the document turns it off (`-a sectnums=@`) **Default**
- Always on (`-a sectnums`)
- Always off (`-a sectnums!`)
- Let the document decide

## Screenshots

![capture du 2016-06-01 02-17-42](https://cloud.githubusercontent.com/assets/5674651/15694552/0af54fde-279f-11e6-828d-c2cd73669592.png)

Fix  #58