### PR TITLE
refactor: section numbering menu

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,14 +33,14 @@ module.exports =
         atom.config.set('asciidoc-preview.tocType', 'preamble')
       'asciidoc-preview:set-toc-macro': ->
         atom.config.set('asciidoc-preview.tocType', 'macro')
-      'asciidoc-preview:set-section-numbering-soft-on': ->
-        atom.config.set('asciidoc-preview.sectionNumbering', 'soft-on')
-      'asciidoc-preview:set-section-numbering-always-on': ->
-        atom.config.set('asciidoc-preview.sectionNumbering', 'always-on')
-      'asciidoc-preview:set-section-numbering-always-off': ->
-        atom.config.set('asciidoc-preview.sectionNumbering', 'always-off')
-      'asciidoc-preview:set-section-numbering-let-document-decide': ->
-        atom.config.set('asciidoc-preview.sectionNumbering', 'let-document-decide')
+      'asciidoc-preview:set-section-numbering-enabled-by-default': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'enabled-by-default')
+      'asciidoc-preview:set-section-numbering-always-enabled': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'always-enabled')
+      'asciidoc-preview:set-section-numbering-always-disabled': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'always-disabled')
+      'asciidoc-preview:set-section-numbering-not-specified': ->
+        atom.config.set('asciidoc-preview.sectionNumbering', 'not-specified')
       'asciidoc-preview:toggle-skip-front-matter': ->
         keyPath = 'asciidoc-preview.skipFrontMatter'
         atom.config.set(keyPath, not atom.config.get(keyPath))

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -54,11 +54,11 @@ calculateTocType = ->
 
 sectionNumbering = ->
   numberedOption = atom.config.get('asciidoc-preview.sectionNumbering')
-  if numberedOption is 'always-on'
+  if numberedOption is 'always-enabled'
     'sectnums'
-  else if numberedOption is 'always-off'
+  else if numberedOption is 'always-disabled'
     'sectnums!'
-  else if numberedOption is 'soft-on'
+  else if numberedOption is 'enabled-by-default'
     'sectnums=@'
   else
     ''

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -16,13 +16,13 @@ menu: [
     ,
       label: 'Section Numbering'
       submenu: [
-        label: 'Soft on', command: 'asciidoc-preview:set-section-numbering-soft-on'
+        label: 'Enabled by default', command: 'asciidoc-preview:set-section-numbering-enabled-by-default'
       ,
-        label: 'Always on', command: 'asciidoc-preview:set-section-numbering-always-on'
+        label: 'Always enabled', command: 'asciidoc-preview:set-section-numbering-always-enabled'
       ,
-        label: 'Always off', command: 'asciidoc-preview:set-section-numbering-always-off'
+        label: 'Always disabled', command: 'asciidoc-preview:set-section-numbering-always-disabled'
       ,
-        label: 'Let the document decide', command: 'asciidoc-preview:set-section-numbering-let-document-decide'
+        label: 'Not specified', command: 'asciidoc-preview:set-section-numbering-not-specified'
       ]
     ,
       label: 'Toggle Document Title', command: 'asciidoc-preview:toggle-show-title'
@@ -55,13 +55,13 @@ menu: [
   ,
     label: 'Section Numbering'
     submenu: [
-      label: 'Soft on', command: 'asciidoc-preview:set-section-numbering-soft-on'
+      label: 'Enabled by default', command: 'asciidoc-preview:set-section-numbering-enabled-by-default'
     ,
-      label: 'Always on', command: 'asciidoc-preview:set-section-numbering-always-on'
+      label: 'Always enabled', command: 'asciidoc-preview:set-section-numbering-always-enabled'
     ,
-      label: 'Always off', command: 'asciidoc-preview:set-section-numbering-always-off'
+      label: 'Always disabled', command: 'asciidoc-preview:set-section-numbering-always-disabled'
     ,
-      label: 'Let the document decide', command: 'asciidoc-preview:set-section-numbering-let-document-decide'
+      label: 'Not specified', command: 'asciidoc-preview:set-section-numbering-not-specified'
     ]
   ,
     label: 'Toggle Compat Mode', command: 'asciidoc-preview:toggle-compat-mode'

--- a/package.json
+++ b/package.json
@@ -78,14 +78,14 @@
       "order": 6
     },
     "sectionNumbering": {
-      "description": "Auto-number section titles.<br>http://asciidoctor.org/docs/user-manual/#numbering",
+      "description": "Auto-number section titles.<br>- Enabled by default (equivalent to `-a sectnums=@`)<br>- Always enabled (equivalent to `-a sectnums`)<br>- Always disabled (equivalent to `-a sectnums!`)<br>- Not specified<br>http://asciidoctor.org/docs/user-manual/#numbering",
       "type": "string",
-      "default": "soft-on",
+      "default": "enabled-by-default",
       "enum": [
-        "soft-on",
-        "always-on",
-        "always-off",
-        "let-document-decide"
+        "enabled-by-default",
+        "always-enabled",
+        "always-disabled",
+        "not-specified"
       ],
       "order": 7
     },


### PR DESCRIPTION
## Description

Rename section numbering options:

- 'soft on' become 'Enabled by default'
- 'Always on' become 'Always enabled'
- 'Always off' become 'Always disabled'
- 'Let the document decide' become 'Not specified'

## Screenshots

![capture du 2016-06-02 08-03-56](https://cloud.githubusercontent.com/assets/5674651/15735478/8c8d42ea-2899-11e6-8291-4b3802f235e9.png)
![ew-053](https://cloud.githubusercontent.com/assets/5674651/15735479/8c8fb214-2899-11e6-81d7-76cdf1838023.png)


