### PR TITLE
fix: substitutions quotes

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -121,17 +121,21 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
 
   for preElement in $.merge(html.filter('pre'), html.find('pre'))
     codeBlock = $(preElement.firstChild)
-    fenceName = codeBlock.attr('class')?.replace(/^language-/, '') ? defaultLanguage
 
-    highlighter ?= new Highlights(registry: atom.grammars)
-    highlightedHtml = highlighter.highlightSync
-      fileContents: codeBlock.text()
-      scopeName: scopeForFenceName(fenceName)
+    # Exclude text node to highlights
+    # Because this creates a rendering bug with quotes substitutions #102
+    if codeBlock[0]?.nodeType isnt Node.TEXT_NODE
+      fenceName = codeBlock.attr('class')?.replace(/^language-/, '') ? defaultLanguage
 
-    highlightedBlock = $(highlightedHtml)
-    # The `editor` class messes things up as `.editor` has absolutely positioned lines
-    highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
-    highlightedBlock.insertAfter(preElement)
-    preElement.remove()
+      highlighter ?= new Highlights(registry: atom.grammars)
+      highlightedHtml = highlighter.highlightSync
+        fileContents: codeBlock.text()
+        scopeName: scopeForFenceName(fenceName)
+
+      highlightedBlock = $(highlightedHtml)
+      # The `editor` class messes things up as `.editor` has absolutely positioned lines
+      highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
+      highlightedBlock.insertAfter(preElement)
+      preElement.remove()
 
   html


### PR DESCRIPTION
## Description

Your description.

## Syntax example

```adoc
[subs=+quotes]
----
# *ip -a*
[ ... Output Abbreviated ... ]
2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP qlen 1000
    link/ether d4:be:d9:b3:8e:0f brd ff:ff:ff:ff:ff:ff
    inet 10.16.154.0/21 brd 10.16.159.255 scope global dynamic em1
       valid_lft 73367sec preferred_lft 73367sec
    inet6 fe80::d6be:d9ff:feb3:8e0f/64 scope link
       valid_lft forever preferred_lft forever
[ ... Output Abbreviated ... ]
----

[options="nowrap", subs="+quotes"]
----
http_proxy=http://__proxy-ip-or-hostname__:__port-number__
----
```

## Screenshots

Before:

![capture du 2016-06-03 00-16-44](https://cloud.githubusercontent.com/assets/5674651/15762891/9aa406ac-2920-11e6-99b1-138e27c67e92.png)

After:

![capture du 2016-06-02 23-58-59](https://cloud.githubusercontent.com/assets/5674651/15762899/a1c35c26-2920-11e6-8a6e-04fc6a303623.png)

Fix  #102