### PR TITLE
refactor: add deserializer configuration

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -11,9 +11,6 @@ class AsciiDocPreviewView extends ScrollView
   @content: ->
     @div class: 'asciidoc-preview native-key-bindings', tabindex: -1
 
-  @deserialize: (state) ->
-    new AsciiDocPreviewView(state)
-
   constructor: ({@editorId, @filePath}) ->
     super
     @emitter = new Emitter

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "mustache": "~2.2.1",
     "underscore-plus": "~1.6.6"
   },
+  "deserializers": {
+    "AsciiDocPreviewView": "createAsciiDocPreviewView"
+  },
   "configSchema": {
     "compatMode": {
       "title": "Compatibility mode (AsciiDoc Python)",


### PR DESCRIPTION
# Description

Restore preview after close or reload Atom.

- preview a document
- close Atom or reloafd (<kbd>crtl+alt+R</kbd>)
- the preview is always opened

Know bug: the pane icon after a restore is breaking. (workaround: close and re-open the preview)