### PR TITLE
feature: export as PDF (experimental)

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -132,8 +132,10 @@ module.exports =
       spawn = require('child_process').spawn
 
       sourceFilePath = target.dataset.path
+
       if process.platform is 'win32'
-        cmd = spawn 'asciidoctor-pdf', [sourceFilePath]
+        shell = process.env['SHELL'] or 'cmd.exe'
+        cmd = spawn 'asciidoctor-pdf.bat', [sourceFilePath], shell: "#{shell} -i -l"
       else
         shell = process.env['SHELL'] or 'bash'
         cmd = spawn 'asciidoctor-pdf', [sourceFilePath], shell: "#{shell} -i -l"

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 url = require 'url'
+path = require 'path'
 fs = require 'fs-plus'
 
 AsciiDocPreviewView = null
@@ -46,13 +47,16 @@ module.exports =
         keyPath = 'asciidoc-preview.renderOnSaveOnly'
         atom.config.set(keyPath, not atom.config.get(keyPath))
 
+    fileExtensions = [
+      'adoc'
+      'asciidoc'
+      'ad'
+      'asc'
+      'txt'
+    ]
     previewFile = @previewFile.bind(this)
-    atom.commands.add '.tree-view .file .name[data-name$=\\.adoc]', 'asciidoc-preview:preview-file', previewFile
-    atom.commands.add '.tree-view .file .name[data-name$=\\.asciidoc]', 'asciidoc-preview:preview-file', previewFile
-    atom.commands.add '.tree-view .file .name[data-name$=\\.ad]', 'asciidoc-preview:preview-file', previewFile
-    atom.commands.add '.tree-view .file .name[data-name$=\\.asc]', 'asciidoc-preview:preview-file', previewFile
-    atom.commands.add '.tree-view .file .name[data-name$=\\.adoc\\.txt]', 'asciidoc-preview:preview-file', previewFile
-    atom.commands.add '.tree-view .file .name[data-name$=\\.txt]', 'asciidoc-preview:preview-file', previewFile
+    atom.commands.add ".tree-view .file .name[data-name$=\\.#{extension}]", 'asciidoc-preview:preview-file', previewFile for extension in fileExtensions
+    atom.commands.add ".tree-view .file .name[data-name$=\\.#{extension}]", 'asciidoc-preview:export-pdf', @exportAsPdf for extension in fileExtensions
 
     atom.workspace.addOpener (uriToOpen) =>
       try
@@ -123,4 +127,37 @@ module.exports =
 
     atom.workspace.open "asciidoc-preview://#{encodeURI(filePath)}", searchAllPanes: true
 
+  exportAsPdf: ({target}) ->
+    if atom.config.get 'asciidoc-preview.experimental.exportAsPdf'
+      spawn = require('child_process').spawn
 
+      sourceFilePath = target.dataset.path
+      if process.platform is 'win32'
+        cmd = spawn 'asciidoctor-pdf', [sourceFilePath]
+      else
+        shell = process.env['SHELL'] or 'bash'
+        cmd = spawn 'asciidoctor-pdf', [sourceFilePath], shell: "#{shell} -i -l"
+
+      cmd.stdout.on 'data', (data) ->
+        atom.notifications.addInfo 'Export as PDF:', detail: data.toString() or '', dismissable: true
+
+      cmd.stderr.on 'data', (data) ->
+        console.error "stderr: #{data}"
+        atom.notifications.addError 'Error:', detail: data.toString() or '', dismissable: true
+
+      cmd.on 'close', (code) ->
+        basename = path.basename(sourceFilePath, path.extname(sourceFilePath))
+        pdfFilePath = path.join(path.dirname(sourceFilePath), basename) + '.pdf'
+
+        if code is 0
+          atom.notifications.addSuccess 'Export as PDF completed!', detail: pdfFilePath or '', dismissable: false
+        else
+          atom.notifications.addWarning 'Export as PDF completed with errors.', detail: pdfFilePath or '', dismissable: false
+
+    else
+      message = '''
+        This feature is experimental.
+        You must manually activate this feature in the package settings.
+        `asciidoctor-pdf` must be installed in you computer.
+        '''
+      atom.notifications.addWarning 'Export as PDF:', detail: message or '', dismissable: true

--- a/menus/asciidoc-preview.cson
+++ b/menus/asciidoc-preview.cson
@@ -67,20 +67,37 @@ menu: [
     label: 'Toggle Compat Mode', command: 'asciidoc-preview:toggle-compat-mode'
   ]
   '.tree-view .file .name[data-name$=\\.adoc]': [
-    label: 'AsciiDoc Preview', command: 'asciidoc-preview:preview-file'
+    label: 'AsciiDoc: Preview', command: 'asciidoc-preview:preview-file'
+  ,
+    label: 'AsciiDoc: Export as PDF', command: 'asciidoc-preview:export-pdf'
+  ,
+    type: 'separator'
   ]
   '.tree-view .file .name[data-name$=\\.asciidoc]': [
-    label: 'AsciiDoc Preview', command: 'asciidoc-preview:preview-file'
+    label: 'AsciiDoc: Preview', command: 'asciidoc-preview:preview-file'
+  ,
+    label: 'AsciiDoc: Export as PDF', command: 'asciidoc-preview:export-pdf'
+  ,
+    type: 'separator'
   ]
   '.tree-view .file .name[data-name$=\\.ad]': [
-    label: 'AsciiDoc Preview', command: 'asciidoc-preview:preview-file'
+    label: 'AsciiDoc: Preview', command: 'asciidoc-preview:preview-file'
+  ,
+    label: 'AsciiDoc: Export as PDF', command: 'asciidoc-preview:export-pdf'
+  ,
+    type: 'separator'
   ]
   '.tree-view .file .name[data-name$=\\.asc]': [
-    label: 'AsciiDoc Preview', command: 'asciidoc-preview:preview-file'
-  ]
-  '.tree-view .file .name[data-name$=\\.adoc\\.txt]': [
-    label: 'AsciiDoc Preview', command: 'asciidoc-preview:preview-file'
+    label: 'AsciiDoc: Preview', command: 'asciidoc-preview:preview-file'
+  ,
+    label: 'AsciiDoc: Export as PDF', command: 'asciidoc-preview:export-pdf'
+  ,
+    type: 'separator'
   ]
   '.tree-view .file .name[data-name$=\\.txt]': [
-    label: 'AsciiDoc Preview', command: 'asciidoc-preview:preview-file'
+    label: 'AsciiDoc: Preview', command: 'asciidoc-preview:preview-file'
+  ,
+    label: 'AsciiDoc: Export as PDF', command: 'asciidoc-preview:export-pdf'
+  ,
+    type: 'separator'
   ]

--- a/package.json
+++ b/package.json
@@ -33,6 +33,19 @@
     "AsciiDocPreviewView": "createAsciiDocPreviewView"
   },
   "configSchema": {
+    "experimental": {
+      "title": "Experimental package features",
+      "type": "object",
+      "collapsed": true,
+      "properties": {
+        "exportAsPdf": {
+          "title": "Export as PDF",
+          "description": "Use [asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf)",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
     "compatMode": {
       "title": "Compatibility mode (AsciiDoc Python)",
       "type": "boolean",

--- a/spec/fixtures/test.asciidoc
+++ b/spec/fixtures/test.asciidoc
@@ -1,5 +1,5 @@
 = Asciidoctor.js 1.5.0 released to Bower and npm!
-Guillaume Grossetie <https://github.com/Mogztter[@Mogztter]>; Anthonny QuÃ©rouil <https://github.com/anthonny[@anthonny]>
+Guillaume Grossetie <https://github.com/Mogztter[@Mogztter]>; Anthonny Quérouil <https://github.com/anthonny[@anthonny]>
 2014-08-23
 :revdate: 2014-08-23 13:20:39 -0600
 // Settings:


### PR DESCRIPTION
## Description

**Experimental feature.**

Export as PDF.

Use [asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf).

Tested with:
- [x] Linux + bash
- [x] Linux + bash + rvm
- [x] OSX
- [x] Windows

## Screenshots

![capture du 2016-06-05 14-30-56](https://cloud.githubusercontent.com/assets/5674651/15805435/90e06172-2b2a-11e6-90cb-4836c01c3b6c.png)
![menu](https://cloud.githubusercontent.com/assets/5674651/15805436/90e39d7e-2b2a-11e6-86bf-ed9b4a3cb83a.png)

Related to  #167