### PR TITLE
feat: add error page for rendering

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -31,9 +31,28 @@ render = (text='', filePath) ->
   new Promise (resolve, reject) ->
     attributes = makeAttributes()
 
-    taskPath = require.resolve './worker'
-    Task.once taskPath, text, attributes, filePath, (html) ->
+    taskPath = require.resolve('./worker')
+    task = Task.once taskPath, text, attributes, filePath
+
+    task.on 'asciidoctor-render:success', ({html}) ->
       resolve html
+
+    task.on 'asciidoctor-render:error', ({code, errno, syscall, stack}) ->
+      resolve """
+        <div>
+          <h1>Asciidoctor.js error</h1>
+          <h2>Rendering error</h2>
+          <div>
+            <p>
+              Currently, an error occurs on Windows with Asciidoctor.js when syntax within a document is invalid.<br>
+              See <a src="https://github.com/asciidoctor/atom-asciidoc-preview/issues/159">https://github.com/asciidoctor/atom-asciidoc-preview/issues/159</a>.
+            </p>
+            <p><b>Please verify your syntax.</b></p>
+            <p>Details: #{stack.split('\n')[0]}</p>
+            <!-- [code: #{code}, errno: #{errno}, syscall: #{syscall}] -->
+          </div>
+        </div>
+        """
 
 sanitize = (html) ->
   o = cheerio.load(html)

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -29,5 +29,17 @@ module.exports = (text, attributes, filePath) ->
     backend: 'html5'
     attributes: concatAttributes.trim()
 
-  html = Asciidoctor.$convert text, options
-  callback html
+  try
+    html = Asciidoctor.$convert text, options
+    emit 'asciidoctor-render:success', html: html
+  catch error
+    console.error error
+    {code, errno, syscall, stack} = error
+    console.error stack
+    emit 'asciidoctor-render:error',
+      code: code
+      errno: errno
+      syscall: syscall
+      stack: stack
+
+  callback()


### PR DESCRIPTION
## Description

On Windows, AsciiDoctor.js try to write when a document have syntax error but this crash the preview.

Now an error page appear.

## Syntax example

See #172 ansd #159.

## Screenshots

![boom1](https://cloud.githubusercontent.com/assets/5674651/15871789/aa857630-2cf6-11e6-9035-c5ec342fe1aa.png)
![boom2](https://cloud.githubusercontent.com/assets/5674651/15871791/aa8cef0a-2cf6-11e6-8675-edcb61ecf5d1.png)
![boom3](https://cloud.githubusercontent.com/assets/5674651/15871790/aa8a9fac-2cf6-11e6-929f-91954e84dc63.png)


