### PR TITLE
Windows stdout hook

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -43,13 +43,10 @@ render = (text='', filePath) ->
           <h1>Asciidoctor.js error</h1>
           <h2>Rendering error</h2>
           <div>
-            <p>
-              Currently, an error occurs on Windows with Asciidoctor.js when syntax within a document is invalid.<br>
-              See <a src="https://github.com/asciidoctor/atom-asciidoc-preview/issues/159">https://github.com/asciidoctor/atom-asciidoc-preview/issues/159</a>.
-            </p>
-            <p><b>Please verify your syntax.</b></p>
+            <p><b>Please verify your document syntax.</b></p>
             <p>Details: #{stack.split('\n')[0]}</p>
-            <!-- [code: #{code}, errno: #{errno}, syscall: #{syscall}] -->
+            <p>[code: #{code}, errno: #{errno}, syscall: #{syscall}]<p>
+            <div>#{stack}</div>
           </div>
         </div>
         """

--- a/lib/std-stream-hook.coffee
+++ b/lib/std-stream-hook.coffee
@@ -1,0 +1,16 @@
+# Hook to prevent errors occurs on Windows with Asciidoctor.js when syntax within a document is invalid.
+# See #159 and #174.
+#
+module.exports =
+  oldStdoutWrite: process.stdout.write
+  oldStderrWrite: process.stderr.write
+
+  hook: ->
+    if process.platform is 'win32'
+      process.stdout.write = (string, encoding, fd) -> console.log string
+      process.stderr.write = (string, encoding, fd) -> console.error string
+
+  restore: ->
+    if process.platform is 'win32'
+      process.stdout.write = @oldStdoutWrite
+      process.stderr.write = @oldStderrWrite

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -2,6 +2,7 @@ ajs = require('asciidoctor.js')()
 Asciidoctor = ajs.Asciidoctor()
 Opal = ajs.Opal
 path = require 'path'
+stdStream = require './std-stream-hook'
 
 module.exports = (text, attributes, filePath) ->
   callback = @async()
@@ -30,7 +31,9 @@ module.exports = (text, attributes, filePath) ->
     attributes: concatAttributes.trim()
 
   try
+    stdStream.hook()
     html = Asciidoctor.$convert text, options
+    stdStream.restore()
     emit 'asciidoctor-render:success', html: html
   catch error
     console.error error


### PR DESCRIPTION
## Description

On Windows, AsciiDoctor.js try to write on `process.stdout` and `process.stderr` when a document have syntax error but this crash the preview.

Now the errors are properly displayed in the console and the document is rendered.

I removed the specific message in the error page.

Fix #172 and #159.
Related to https://github.com/electron/electron/issues/2033
