### PR TITLE
feat: open generated HTML file in browser

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -4,6 +4,7 @@ path = require 'path'
 fs = require 'fs-plus'
 _ = require 'underscore-plus'
 mustache = require 'mustache'
+opn = require 'opn'
 renderer = require './renderer'
 
 module.exports =
@@ -261,4 +262,10 @@ class AsciiDocPreviewView extends ScrollView
         .then (htmlContent) ->
           fs.writeFileSync htmlFilePath, htmlContent
         .then ->
-          atom.workspace.open htmlFilePath
+          if atom.config.get 'asciidoc-preview.saveAsHtml.openInEditor'
+            atom.workspace.open htmlFilePath
+
+          if atom.config.get 'asciidoc-preview.saveAsHtml.openInBrowser'
+            opn(filePath).catch (error) ->
+              atom.notifications.addError error.toString(), detail: error?.stack or '', dismissable: true
+              console.error error

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "font-awesome": "^4.6.3",
     "fs-plus": "~2.8.2",
     "mustache": "~2.2.1",
+    "opn": "^4.0.2",
     "underscore-plus": "~1.6.6"
   },
   "devDependencies": {
@@ -137,6 +138,24 @@
         "text.plain.null-grammar"
       ],
       "order": 11
+    },
+    "saveAsHtml": {
+      "title": "Save as HTML",
+      "type": "object",
+      "collapsed": true,
+      "properties": {
+        "openInEditor": {
+          "title": "Open the generated HTML source code in Atom.",
+          "type": "boolean",
+          "default": false
+        },
+        "openInBrowser": {
+          "title": "Open the generated HTML file in your default browser.",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "order": 12
     }
   }
 }


### PR DESCRIPTION
## Description

Allow to automatically open generated HTML in the default browser.

## Screenshots

![capture du 2016-06-12 18-32-08](https://cloud.githubusercontent.com/assets/5674651/15992424/07a03ba6-30cc-11e6-99bb-8597590bec65.png)


