### PR TITLE
refactor: move base directory construct

### DIFF
--- a/lib/attributes-builder.coffee
+++ b/lib/attributes-builder.coffee
@@ -1,6 +1,7 @@
+path = require 'path'
 
 module.exports =
-  makeAttributes: ->
+  makeAttributes: (filePath) ->
     attributes =
       defaultAttributes: atom.config.get 'asciidoc-preview.defaultAttributes'
       numbered: sectionNumbering()
@@ -10,15 +11,16 @@ module.exports =
       forceExperimental: if atom.config.get 'asciidoc-preview.forceExperimental' then 'experimental' else ''
       tocType: calculateTocType()
       safeMode: atom.config.get 'asciidoc-preview.safeMode' or 'safe'
+      baseDir: path.dirname filePath if filePath
       opalPwd: window.location.href
 
 calculateTocType = ->
   tocType = atom.config.get 'asciidoc-preview.tocType'
   if tocType is 'none'
     ''
-  # NOTE: 'auto' (blank option in asciidoctor) is currently not supported but
-  # this section is left as a reminder of the expected behaviour
   else if tocType is 'auto'
+    # NOTE: 'auto' (blank option in asciidoctor) is currently not supported but
+    # this section is left as a reminder of the expected behaviour
     'toc=toc! toc2!'
   else
     "toc=#{tocType} toc2!"

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -29,10 +29,10 @@ render = (text='', filePath) ->
   return Promise.resolve() unless atom.config.get('asciidoc-preview.defaultAttributes')?
 
   new Promise (resolve, reject) ->
-    attributes = makeAttributes()
+    attributes = makeAttributes filePath
 
     taskPath = require.resolve('./worker')
-    task = Task.once taskPath, text, attributes, filePath
+    task = Task.once taskPath, text, attributes
 
     task.on 'asciidoctor-render:success', ({html}) ->
       resolve html

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -4,7 +4,7 @@ Opal = ajs.Opal
 path = require 'path'
 stdStream = require './std-stream-hook'
 
-module.exports = (text, attributes, filePath) ->
+module.exports = (text, attributes) ->
   callback = @async()
 
   concatAttributes = [
@@ -16,19 +16,17 @@ module.exports = (text, attributes, filePath) ->
     attributes.compatMode
     attributes.tocType
     attributes.forceExperimental
-  ].join ' '
-
-  folder = path.dirname(filePath)
+  ].join(' ').trim()
 
   Opal.ENV['$[]=']('PWD', path.dirname(attributes.opalPwd))
 
   options = Opal.hash
-    base_dir: folder
+    base_dir: attributes.baseDir
     safe: attributes.safeMode
     doctype: 'article'
     # Force backend to html5
     backend: 'html5'
-    attributes: concatAttributes.trim()
+    attributes: concatAttributes
 
   try
     stdStream.hook()

--- a/spec/attributes-builder-spec.coffee
+++ b/spec/attributes-builder-spec.coffee
@@ -138,6 +138,18 @@ describe "attributes-builder", ->
 
       expect(safeMode).toBe 'secure'
 
+  describe "Base directory", ->
+
+    it 'when filePath is undefined', ->
+      {baseDir} = makeAttributes()
+
+      expect(baseDir).toBeUndefined()
+
+    it 'when filePath is defined', ->
+      {baseDir} = makeAttributes('foo/bar.adoc')
+
+      expect(baseDir).toBe 'foo'
+
   describe "opalPwd", ->
 
     it 'should opalPwd be defined', ->


### PR DESCRIPTION
## Description

Move the construct of `base_dir` from `worker.coffee` to `attributes-builder.coffee`