### PR TITLE
feat: base directory management

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -127,6 +127,9 @@ class AsciiDocPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'asciidoc-preview.tocType', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.frontMatter', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.sectionNumbering', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.forceExperimental', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.baseDir.auto', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.baseDir.customPath', changeHandler
 
   renderAsciiDoc: ->
     @showLoading() unless @loaded

--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -128,8 +128,7 @@ class AsciiDocPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'asciidoc-preview.frontMatter', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.sectionNumbering', changeHandler
     @disposables.add atom.config.onDidChange 'asciidoc-preview.forceExperimental', changeHandler
-    @disposables.add atom.config.onDidChange 'asciidoc-preview.baseDir.auto', changeHandler
-    @disposables.add atom.config.onDidChange 'asciidoc-preview.baseDir.customPath', changeHandler
+    @disposables.add atom.config.onDidChange 'asciidoc-preview.baseDir', changeHandler
 
   renderAsciiDoc: ->
     @showLoading() unless @loaded

--- a/lib/attributes-builder.coffee
+++ b/lib/attributes-builder.coffee
@@ -37,7 +37,8 @@ sectionNumbering = ->
     ''
 
 makeBaseDirectory = (filePath) ->
-  if atom.config.get 'asciidoc-preview.baseDir.auto'
+  baseBir = atom.config.get('asciidoc-preview.baseDir')
+  if baseBir is '{docdir}'
     path.dirname filePath
-  else if atom.config.get 'asciidoc-preview.baseDir.customPath'
-    atom.config.get 'asciidoc-preview.baseDir.customPath'
+  else if baseBir isnt '-'
+    baseBir

--- a/lib/attributes-builder.coffee
+++ b/lib/attributes-builder.coffee
@@ -11,7 +11,7 @@ module.exports =
       forceExperimental: if atom.config.get 'asciidoc-preview.forceExperimental' then 'experimental' else ''
       tocType: calculateTocType()
       safeMode: atom.config.get 'asciidoc-preview.safeMode' or 'safe'
-      baseDir: path.dirname filePath if filePath
+      baseDir: makeBaseDirectory filePath if filePath
       opalPwd: window.location.href
 
 calculateTocType = ->
@@ -35,3 +35,9 @@ sectionNumbering = ->
     'sectnums=@'
   else
     ''
+
+makeBaseDirectory = (filePath) ->
+  if atom.config.get 'asciidoc-preview.baseDir.auto'
+    path.dirname filePath
+  else if atom.config.get 'asciidoc-preview.baseDir.customPath'
+    atom.config.get 'asciidoc-preview.baseDir.customPath'

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
       "collapsed": true,
       "properties": {
         "auto": {
-          "title": "Automatically relativized from document path.",
+          "title": "Automatically set base directory to match document directory.",
           "description": "More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
           "type": "boolean",
           "default": true,
@@ -177,7 +177,7 @@
         },
         "customPath": {
           "title": "Custom base directory",
-          "description": "Only works when _Automatically relativized from document path_ is unchecked.<br>More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
+          "description": "Only works when _Automatically set base directory to match document directory_ is unchecked.<br>More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
           "type": "string",
           "default": "",
           "order": 2

--- a/package.json
+++ b/package.json
@@ -34,24 +34,6 @@
     "AsciiDocPreviewView": "createAsciiDocPreviewView"
   },
   "configSchema": {
-    "exportAsPdf": {
-      "title": "Export as PDF (experimental)",
-      "type": "object",
-      "collapsed": true,
-      "properties": {
-        "enabled": {
-          "title": "Use asciidoctor-pdf",
-          "description": "[asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf) must be installed in your system.",
-          "type": "boolean",
-          "default": false
-        },
-        "openWithExternal": {
-          "title": "Automatically open the PDF after generation with the default PDF viewer.",
-          "type": "boolean",
-          "default": true
-        }
-      }
-    },
     "compatMode": {
       "title": "Compatibility mode (AsciiDoc Python)",
       "type": "boolean",
@@ -161,6 +143,47 @@
         }
       },
       "order": 12
+    },
+    "exportAsPdf": {
+      "title": "Export as PDF [experimental]",
+      "type": "object",
+      "collapsed": true,
+      "properties": {
+        "enabled": {
+          "title": "Use asciidoctor-pdf",
+          "description": "[asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf) must be installed in your system.",
+          "type": "boolean",
+          "default": false
+        },
+        "openWithExternal": {
+          "title": "Automatically open the PDF after generation with the default PDF viewer.",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "order": 13
+    },
+    "baseDir": {
+      "title": "Base directory (base_dir) [advanced]",
+      "type": "object",
+      "collapsed": true,
+      "properties": {
+        "auto": {
+          "title": "Automatically relativized from document path.",
+          "description": "More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
+          "type": "boolean",
+          "default": true,
+          "order": 1
+        },
+        "customPath": {
+          "title": "Custom base directory",
+          "description": "Only works when _Automatically relativized from document path_ is unchecked.<br>More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
+          "type": "string",
+          "default": "",
+          "order": 2
+        }
+      },
+      "order": 14
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,17 +34,21 @@
     "AsciiDocPreviewView": "createAsciiDocPreviewView"
   },
   "configSchema": {
-    "compatMode": {
-      "title": "Compatibility mode (AsciiDoc Python)",
+    "renderOnSaveOnly": {
+      "title": "Render on save only",
       "type": "boolean",
       "default": false,
       "order": 1
     },
-    "forceExperimental": {
-      "title": "Always enable experimental extensions",
-      "description": "The features behind this attribute are subject to change and may even be removed in a future version.<br>Currently enables the UI macros (`button`, `menu` and `kbd`).",
-      "type": "boolean",
-      "default": false,
+    "openInPane": {
+      "type": "string",
+      "default": "right",
+      "enum": [
+        "left",
+        "right",
+        "up",
+        "down"
+      ],
       "order": 2
     },
     "showTitle": {
@@ -53,15 +57,15 @@
       "default": true,
       "order": 3
     },
-    "safeMode": {
-      "description": "Set safe mode 'level': `unsafe`, `safe`, `server` or `secure`.<br>Disables potentially dangerous macros in source files, such as `include::[]`.<br>Set safe mode level to `safe` to enable include macros, but restricts access to ancestor paths of source file.<br>http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely<br>",
+    "sectionNumbering": {
+      "description": "Auto-number section titles.<br>- Enabled by default (equivalent to `-a sectnums=@`)<br>- Always enabled (equivalent to `-a sectnums`)<br>- Always disabled (equivalent to `-a sectnums!`)<br>- Not specified<br>http://asciidoctor.org/docs/user-manual/#numbering",
       "type": "string",
-      "default": "safe",
+      "default": "enabled-by-default",
       "enum": [
-        "unsafe",
-        "safe",
-        "server",
-        "secure"
+        "enabled-by-default",
+        "always-enabled",
+        "always-disabled",
+        "not-specified"
       ],
       "order": 4
     },
@@ -84,38 +88,42 @@
       "default": false,
       "order": 6
     },
-    "sectionNumbering": {
-      "description": "Auto-number section titles.<br>- Enabled by default (equivalent to `-a sectnums=@`)<br>- Always enabled (equivalent to `-a sectnums`)<br>- Always disabled (equivalent to `-a sectnums!`)<br>- Not specified<br>http://asciidoctor.org/docs/user-manual/#numbering",
-      "type": "string",
-      "default": "enabled-by-default",
-      "enum": [
-        "enabled-by-default",
-        "always-enabled",
-        "always-disabled",
-        "not-specified"
-      ],
+    "forceExperimental": {
+      "title": "Always enable AsciiDoctor experimental extensions",
+      "description": "The features behind this attribute are subject to change and may even be removed in a future version of AsciiDoctor.<br>Currently enables the UI macros (`button`, `menu` and `kbd`).",
+      "type": "boolean",
+      "default": false,
       "order": 7
     },
-    "renderOnSaveOnly": {
+    "compatMode": {
+      "title": "Always enable compatibility mode (AsciiDoc Python)",
       "type": "boolean",
       "default": false,
       "order": 8
     },
-    "openInPane": {
+    "safeMode": {
+      "description": "Set safe mode 'level': `unsafe`, `safe`, `server` or `secure`.<br>Disables potentially dangerous macros in source files, such as `include::[]`.<br>Set safe mode level to `safe` to enable include macros, but restricts access to ancestor paths of source file.<br>http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely<br>",
       "type": "string",
-      "default": "right",
+      "default": "safe",
       "enum": [
-        "left",
-        "right",
-        "up",
-        "down"
+        "unsafe",
+        "safe",
+        "server",
+        "secure"
       ],
       "order": 9
+    },
+    "baseDir": {
+      "title": "Base directory",
+      "description": "Use the value `{docdir}` to make the base directory match the document directory.<br>Use the value `-` to use absolute path.<br>More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
+      "type" : "string",
+      "default": "{docdir}",
+      "order": 10
     },
     "defaultAttributes": {
       "type": "string",
       "default": "platform=opal platform-opal env=browser env-browser source-highlighter=highlight.js data-uri!",
-      "order": 10
+      "order": 11
     },
     "grammars": {
       "type": "array",
@@ -124,7 +132,7 @@
         "text.plain",
         "text.plain.null-grammar"
       ],
-      "order": 11
+      "order": 12
     },
     "saveAsHtml": {
       "title": "Save as HTML",
@@ -142,7 +150,7 @@
           "default": true
         }
       },
-      "order": 12
+      "order": 13
     },
     "exportAsPdf": {
       "title": "Export as PDF [experimental]",
@@ -159,28 +167,6 @@
           "title": "Automatically open the PDF after generation with the default PDF viewer.",
           "type": "boolean",
           "default": true
-        }
-      },
-      "order": 13
-    },
-    "baseDir": {
-      "title": "Base directory (base_dir) [advanced]",
-      "type": "object",
-      "collapsed": true,
-      "properties": {
-        "auto": {
-          "title": "Automatically set base directory to match document directory.",
-          "description": "More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
-          "type": "boolean",
-          "default": true,
-          "order": 1
-        },
-        "customPath": {
-          "title": "Custom base directory",
-          "description": "Only works when _Automatically set base directory to match document directory_ is unchecked.<br>More informations: http://asciidoctor.org/docs/user-manual/#ruby-api-options",
-          "type": "string",
-          "default": "",
-          "order": 2
         }
       },
       "order": 14

--- a/spec/attributes-builder-spec.coffee
+++ b/spec/attributes-builder-spec.coffee
@@ -140,34 +140,26 @@ describe "attributes-builder", ->
 
   describe "Base directory", ->
 
-    it 'when filePath is undefined and automatically relativized from document path', ->
-      atom.config.set 'asciidoc-preview.baseDir.auto', true
+    it 'when filePath is undefined and document path as base_dir', ->
+      atom.config.set 'asciidoc-preview.baseDir', '{docdir}'
       {baseDir} = makeAttributes()
 
       expect(baseDir).toBeUndefined()
 
-    it 'when filePath is defined and automatically relativized from document path', ->
-      atom.config.set 'asciidoc-preview.baseDir.auto', true
+    it 'when filePath is defined and document path as base_dir', ->
+      atom.config.set 'asciidoc-preview.baseDir', '{docdir}'
       {baseDir} = makeAttributes 'foo/bar.adoc'
 
       expect(baseDir).toBe 'foo'
 
-    it 'when filePath is defined and customPath is defined and automatically relativized from document path', ->
-      atom.config.set 'asciidoc-preview.baseDir.auto', true
-      atom.config.set 'asciidoc-preview.baseDir.customPath', 'fii'
-      {baseDir} = makeAttributes 'foo/bar.adoc'
-
-      expect(baseDir).toBe 'foo'
-
-    it 'when filePath is defined and not automatically relativized from document path', ->
-      atom.config.set 'asciidoc-preview.baseDir.auto', false
+    it 'when filePath is defined and use absolute path', ->
+      atom.config.set 'asciidoc-preview.baseDir', '-'
       {baseDir} = makeAttributes 'foo/bar.adoc'
 
       expect(baseDir).toBeUndefined()
 
-    it 'when customPath is defined and not automatically relativized from document path', ->
-      atom.config.set 'asciidoc-preview.baseDir.auto', false
-      atom.config.set 'asciidoc-preview.baseDir.customPath', 'fii'
+    it 'when use a custom base_dir', ->
+      atom.config.set 'asciidoc-preview.baseDir', 'fii'
       {baseDir} = makeAttributes 'foo/bar.adoc'
 
       expect(baseDir).toBe 'fii'

--- a/spec/attributes-builder-spec.coffee
+++ b/spec/attributes-builder-spec.coffee
@@ -140,15 +140,37 @@ describe "attributes-builder", ->
 
   describe "Base directory", ->
 
-    it 'when filePath is undefined', ->
+    it 'when filePath is undefined and automatically relativized from document path', ->
+      atom.config.set 'asciidoc-preview.baseDir.auto', true
       {baseDir} = makeAttributes()
 
       expect(baseDir).toBeUndefined()
 
-    it 'when filePath is defined', ->
-      {baseDir} = makeAttributes('foo/bar.adoc')
+    it 'when filePath is defined and automatically relativized from document path', ->
+      atom.config.set 'asciidoc-preview.baseDir.auto', true
+      {baseDir} = makeAttributes 'foo/bar.adoc'
 
       expect(baseDir).toBe 'foo'
+
+    it 'when filePath is defined and customPath is defined and automatically relativized from document path', ->
+      atom.config.set 'asciidoc-preview.baseDir.auto', true
+      atom.config.set 'asciidoc-preview.baseDir.customPath', 'fii'
+      {baseDir} = makeAttributes 'foo/bar.adoc'
+
+      expect(baseDir).toBe 'foo'
+
+    it 'when filePath is defined and not automatically relativized from document path', ->
+      atom.config.set 'asciidoc-preview.baseDir.auto', false
+      {baseDir} = makeAttributes 'foo/bar.adoc'
+
+      expect(baseDir).toBeUndefined()
+
+    it 'when customPath is defined and not automatically relativized from document path', ->
+      atom.config.set 'asciidoc-preview.baseDir.auto', false
+      atom.config.set 'asciidoc-preview.baseDir.customPath', 'fii'
+      {baseDir} = makeAttributes 'foo/bar.adoc'
+
+      expect(baseDir).toBe 'fii'
 
   describe "opalPwd", ->
 


### PR DESCRIPTION
## Description

Advanced base directory management.
- `base_dir`

Related to #182

## Syntax example

```adoc
include::/home/ldez/foobar.doc[]
```

## Screenshots

![capture du 2016-06-17 02-50-39](https://cloud.githubusercontent.com/assets/5674651/16137731/4d5b59ba-3436-11e6-9bc0-aacbb24e089c.png)

