### PR TITLE
fix: text code block

### DIFF
--- a/lib/configuration-builder.coffee
+++ b/lib/configuration-builder.coffee
@@ -40,7 +40,7 @@ sectionNumbering = ->
     ''
 
 makeBaseDirectory = (filePath) ->
-  baseBir = atom.config.get('asciidoc-preview.baseDir')
+  baseBir = atom.config.get 'asciidoc-preview.baseDir'
   if baseBir is '{docdir}'
     path.dirname filePath
   else if baseBir isnt '-'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -124,15 +124,20 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
     if codeBlock[0]?.nodeType isnt Node.TEXT_NODE
       fenceName = codeBlock.attr('class')?.replace(/^language-/, '') ? defaultLanguage
 
-      highlighter ?= new Highlights(registry: atom.grammars)
-      highlightedHtml = highlighter.highlightSync
-        fileContents: codeBlock.text()
-        scopeName: scopeForFenceName(fenceName)
+      # Exclude text block that contains HTML to highlights
+      # Because this creates a rendering bug with quotes substitutions #193
+      if fenceName is defaultLanguage and codeBlock.length
+        preElement.className = ''
+      else
+        highlighter ?= new Highlights(registry: atom.grammars)
+        highlightedHtml = highlighter.highlightSync
+          fileContents: codeBlock.text()
+          scopeName: scopeForFenceName(fenceName)
 
-      highlightedBlock = $(highlightedHtml)
-      # The `editor` class messes things up as `.editor` has absolutely positioned lines
-      highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
-      highlightedBlock.insertAfter(preElement)
-      preElement.remove()
+        highlightedBlock = $(highlightedHtml)
+        # The `editor` class messes things up as `.editor` has absolutely positioned lines
+        highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
+        highlightedBlock.insertAfter(preElement)
+        preElement.remove()
 
   html

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -124,9 +124,9 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
     if codeBlock[0]?.nodeType isnt Node.TEXT_NODE
       fenceName = codeBlock.attr('class')?.replace(/^language-/, '') ? defaultLanguage
 
-      # Exclude text block that contains HTML to highlights
+      # Exclude text block to highlights
       # Because this creates a rendering bug with quotes substitutions #193
-      if fenceName is defaultLanguage and codeBlock.length
+      if fenceName is defaultLanguage
         preElement.className = ''
       else
         highlighter ?= new Highlights(registry: atom.grammars)


### PR DESCRIPTION
## Description

Fix raw text code block highlighting. 

## Syntax example

```adoc
= Test

[subs="+quotes"]
----
__JWS_HOME__\sbin\tomcat__<VERSION>__.exe //US//Tomcat__<VERSION>__ ++JvmOptions="-Dcom.sun.management.jmxremote.port=8100;-Dcom.sun.management.jmxremote.access.file="C:\jmx\jmxremote.access";-Dcom.sun.management.jmxremote.password.file="C:\jmx\jmxremote.password";-Dcom.sun.management.jmxremote.ssl=false;-Dcom.sun.management.jmxremote.authenticate=true"
----
```

## Screenshots

![capture du 2016-07-11 19-51-45](https://cloud.githubusercontent.com/assets/5674651/16740789/ee23280a-47a0-11e6-9779-31cc8d28c678.png)

Fix #193
Related to #102