### PR TITLE
fix(pdf): remove bash interactive option

### DIFF
--- a/lib/pdf-converter.coffee
+++ b/lib/pdf-converter.coffee
@@ -44,7 +44,7 @@ executeAsciiDoctorPdf = (sourceFilePath) ->
 
   if process.platform is 'win32'
     shell = process.env['SHELL'] or 'cmd.exe'
-    spawn 'asciidoctor-pdf.bat', [sourceFilePath], shell: "#{shell} -i -l"
+    spawn 'asciidoctor-pdf.bat', [sourceFilePath], shell: "#{shell}"
   else
     shell = process.env['SHELL'] or 'bash'
-    spawn 'asciidoctor-pdf', [sourceFilePath], shell: "#{shell} -i -l"
+    spawn 'asciidoctor-pdf', [sourceFilePath], shell: "#{shell}"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "asciidoc-preview"
   ],
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.9.0 <2.0.0"
   },
   "dependencies": {
     "asciidoctor.js": "1.5.5-1",


### PR DESCRIPTION
## Description

Related to Atom 1.9 update.

Fixed on Windows, Linux and MacOS

Fix #195 