### PR TITLE
Synchronize the preview pane with the AsciiDoc source pane

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -111,9 +111,19 @@ class AsciiDocPreviewView extends ScrollView
       saveOnly = atom.config.get('asciidoc-preview.renderOnSaveOnly')
       changeHandler() if not saveOnly
 
+    scrollPreview = (event, callback) ->
+      blockId = renderer.getBlockId event.newBufferPosition.row
+      if blockId?
+        if target = $('#' + blockId)[0]
+          callback target.offsetTop
+      else
+        # TODO Find the nearest block
+
     if @file?
       @disposables.add @file.onDidChange changeHandler
     else if @editor?
+      @disposables.add @editor.onDidChangeCursorPosition (event) => scrollPreview event, (top) =>
+        @scrollTop top
       @disposables.add @editor.onDidChangePath => @emitter.emit 'did-change-title'
       buffer = @editor.getBuffer()
       @disposables.add buffer.onDidStopChanging renderOnChange
@@ -162,9 +172,9 @@ class AsciiDocPreviewView extends ScrollView
         # Because jQuery uses CSS syntax for selecting elements, some characters are interpreted as CSS notation.
         # In order to tell jQuery to treat these characters literally rather than as CSS notation, they must be "escaped" by placing two backslashes in front of them.
         if target = $(hrefLink.replace(/(\/|:|\.|\[|\]|,|\)|\()/g, '\\$1'))
-          continue if not target.offset()
+          continue if not target[0]
           # TODO Use tab height variable instead of 43
-          top = target.offset().top - 43
+          top = target[0].offsetTop
           do (top) ->
             link.on 'click', (e) ->
               top = top

--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -108,22 +108,22 @@ class AsciiDocPreviewView extends ScrollView
         pane.activateItem(this)
 
     renderOnChange = ->
-      saveOnly = atom.config.get('asciidoc-preview.renderOnSaveOnly')
+      saveOnly = atom.config.get 'asciidoc-preview.renderOnSaveOnly'
       changeHandler() if not saveOnly
 
     scrollPreview = (event, callback) ->
-      blockId = renderer.getBlockId event.newBufferPosition.row
-      if blockId?
-        if target = $('#' + blockId)[0]
-          callback target.offsetTop
-      else
-        # TODO Find the nearest block
+      if atom.config.get 'asciidoc-preview.scrollMode'
+        blockId = renderer.getBlockId event.newBufferPosition.row
+        if blockId?
+          if target = $('#' + blockId)[0]
+            callback target.offsetTop
+        # else
+          # TODO Find the nearest block
 
     if @file?
       @disposables.add @file.onDidChange changeHandler
     else if @editor?
-      @disposables.add @editor.onDidChangeCursorPosition (event) => scrollPreview event, (top) =>
-        @scrollTop top
+      @disposables.add @editor.onDidChangeCursorPosition (event) => scrollPreview event, (top) => @scrollTop top
       @disposables.add @editor.onDidChangePath => @emitter.emit 'did-change-title'
       buffer = @editor.getBuffer()
       @disposables.add buffer.onDidStopChanging renderOnChange

--- a/lib/configuration-builder.coffee
+++ b/lib/configuration-builder.coffee
@@ -16,6 +16,7 @@ module.exports =
       opalPwd: window.location.href
       baseDir: (makeBaseDirectory filePath if filePath)
       safeMode: atom.config.get 'asciidoc-preview.safeMode' or 'safe'
+      scrollMode: atom.config.get 'asciidoc-preview.scrollMode'
 
 calculateTocType = ->
   tocType = atom.config.get 'asciidoc-preview.tocType'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -25,15 +25,21 @@ exports.toHtml = (text='', filePath) ->
 exports.toRawHtml = (text='', filePath) ->
   render text, filePath
 
-render = (text='', filePath) ->
+exports.getBlockId = (bufferRowPosition) =>
+  @blocksPositions[bufferRowPosition + 1] if @blocksPositions
+
+render = (text='', filePath) =>
   return Promise.resolve() unless atom.config.get('asciidoc-preview.defaultAttributes')?
 
-  new Promise (resolve, reject) ->
+  new Promise (resolve, reject) =>
     attributes = makeAttributes()
     options = makeOptions filePath
 
     taskPath = require.resolve('./worker')
     task = Task.once taskPath, text, attributes, options
+
+    task.on 'asciidoctor-load:success', ({blocksPositions}) =>
+      @blocksPositions = blocksPositions
 
     task.on 'asciidoctor-render:success', ({html}) ->
       console.warn "Rendering is empty: #{filePath}" if not html

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -20,20 +20,23 @@ module.exports = (text, attributes, options) ->
 
   Opal.ENV['$[]=']('PWD', path.dirname(options.opalPwd))
 
-  options = Opal.hash
+  asciidoctorOptions = Opal.hash
     base_dir: options.baseDir
     safe: options.safeMode
     doctype: 'article'
     # Force backend to html5
     backend: 'html5'
     attributes: concatAttributes
-    sourcemap: true
+    sourcemap: options.scrollMode
 
   try
     stdStream.hook()
-    doc = Asciidoctor.$load text, options
-    blocksPositions = registerBlocksPositions doc.blocks, {}, 1
-    emit 'asciidoctor-load:success', blocksPositions: blocksPositions
+    doc = Asciidoctor.$load text, asciidoctorOptions
+
+    if options.scrollMode
+      blocksPositions = registerBlocksPositions doc.blocks, {}, 1
+      emit 'asciidoctor-load:success', blocksPositions: blocksPositions
+
     html = doc.$convert()
     stdStream.restore()
     emit 'asciidoctor-render:success', html: html

--- a/package.json
+++ b/package.json
@@ -34,6 +34,13 @@
     "AsciiDocPreviewView": "createAsciiDocPreviewView"
   },
   "configSchema": {
+    "scrollMode": {
+      "title": "Synchronize the preview pane",
+      "description": "If set, synchronize the preview pane with the AsciiDoc source pane.<br>WARNING: The scroll position on the preview pane does not automatically scroll the AsciiDoc source pane.",
+      "type": "boolean",
+      "default": true,
+      "order": 0
+    },
     "renderOnSaveOnly": {
       "title": "Render on save only",
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asciidoc-preview",
   "main": "./lib/main",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Show an HTML preview for the AsciiDoc content in the current editor",
   "repository": "https://github.com/asciidoctor/atom-asciidoc-preview",
   "license": "MIT",

--- a/spec/worker-spec.coffee
+++ b/spec/worker-spec.coffee
@@ -1,0 +1,32 @@
+{Task} = require 'atom'
+
+describe "worker", ->
+
+  it 'should generate blocks positions', ->
+    options =
+      opalPwd: window.location.href
+
+    content = """= Hello world
+
+    == First section
+
+    First paragraph.
+    Second paragraph.
+
+    == Second section
+
+    Third paragraph.
+    Fourth paragraph."""
+
+    task = Task.once require.resolve('../lib/worker'), content, {}, options
+
+    task.on 'asciidoctor-load:success', ({blocksPositions}) =>
+      @blocksPositions = blocksPositions
+
+    waitsFor (done) -> task.start(done)
+
+    runs =>
+      expect(@blocksPositions[3]).toBe '_first_section'
+      expect(@blocksPositions[5]).toBe 'paragraph_1'
+      expect(@blocksPositions[8]).toBe '_second_section'
+      expect(@blocksPositions[10]).toBe 'paragraph_2'

--- a/spec/worker-spec.coffee
+++ b/spec/worker-spec.coffee
@@ -1,6 +1,6 @@
 {Task} = require 'atom'
 
-describe "worker", ->
+describe 'worker', ->
 
   it 'should generate blocks positions', ->
     options =


### PR DESCRIPTION
## Description

Automatically scroll the preview pane from the cursor position on the AsciiDoc source pane.
NOTE: The scroll position on the preview pane does *not* automatically scroll the AsciiDoc source pane.

Ref #82

NOTE: `sourcemap` option does *not* map all the blocks on the AST. For instance list item are not map. So if you have a long list of items, the preview pane will not scroll down as you look over your list of items.

## Screenshots

![sync](https://cloud.githubusercontent.com/assets/333276/22622578/50608940-eb3e-11e6-9f3a-79abf9814e83.PNG)

## TODO

 * [x] Add tests 
 * [ ] Add an option to enable/disable this feature

