### PR TITLE
feat(pdf): support filenames with whitespaces.

### DIFF
--- a/lib/pdf-converter.coffee
+++ b/lib/pdf-converter.coffee
@@ -44,7 +44,7 @@ executeAsciiDoctorPdf = (sourceFilePath) ->
 
   if process.platform is 'win32'
     shell = process.env['SHELL'] or 'cmd.exe'
-    spawn 'asciidoctor-pdf.bat', [sourceFilePath], shell: "#{shell}"
+    spawn 'asciidoctor-pdf.bat', ["\"#{sourceFilePath}\""], shell: "#{shell}"
   else
     shell = process.env['SHELL'] or 'bash'
-    spawn 'asciidoctor-pdf', [sourceFilePath], shell: "#{shell}"
+    spawn 'asciidoctor-pdf', ["\"#{sourceFilePath}\""], shell: "#{shell}"


### PR DESCRIPTION
## Description

The "AsciiDoc: Export as PDF" option fails for files with whitespaces in them and complains for a missing file with an incomplete filename.

## Syntax example

```adoc
= Title

== Test

This is a test.
```

## Screenshots

![capture du 2017-02-16 22-06-04](https://cloud.githubusercontent.com/assets/5674651/23041137/27f88868-f494-11e6-936c-dc2275413dac.png)

Fix #212