### PR TITLE
fix: Highlights on Fedora.

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -10,7 +10,7 @@ commonHighlightsPath = path.join markdownPreviewPath, '..', 'highlights'
 if fs.isDirectorySync commonHighlightsPath
   Highlights = require commonHighlightsPath
 else
-  # Fix Fedora specific problem #226
+  # Fix specific problem with RPM made for Fedora by the Fedora community. See #226.
   Highlights = require path.join markdownPreviewPath, 'node_modules', 'highlights'
 
 {scopeForFenceName} = require './highlights-helper'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -3,8 +3,16 @@
 path = require 'path'
 fs = require 'fs-plus'
 cheerio = require 'cheerio'
+
 # No direct dependence with Highlight because it requires a compilation. See #63 and #150 and atom/highlights#36.
-Highlights = require path.join atom.packages.resolvePackagePath('markdown-preview'), '..', 'highlights'
+markdownPreviewPath = atom.packages.resolvePackagePath 'markdown-preview'
+commonHighlightsPath = path.join markdownPreviewPath, '..', 'highlights'
+if fs.isDirectorySync commonHighlightsPath
+  Highlights = require commonHighlightsPath
+else
+  # Fix Fedora specific problem #226
+  Highlights = require path.join markdownPreviewPath, 'node_modules', 'highlights'
+
 {scopeForFenceName} = require './highlights-helper'
 
 {makeAttributes, makeOptions} = require './configuration-builder'


### PR DESCRIPTION
## Description

Fix Highlights module path on Fedora.

Fixes #223, #226 
