### PR TITLE
refactor: change Highlights provider.

### DIFF
--- a/lib/highlights.coffee
+++ b/lib/highlights.coffee
@@ -1,0 +1,69 @@
+# Inspired by https://github.com/atom-haskell/atom-highlights
+
+_ = require 'underscore-plus'
+
+pushScope = (scopeStack, scope, html) ->
+  scopeStack.push(scope)
+  html += "<span class=\"#{scope.replace(/\.+/g, ' ')}\">"
+
+popScope = (scopeStack, html) ->
+  scopeStack.pop()
+  html += '</span>'
+
+updateScopeStack = (scopeStack, desiredScopes, html) ->
+  excessScopes = scopeStack.length - desiredScopes.length
+  if excessScopes > 0
+    html = popScope(scopeStack, html) while excessScopes--
+
+  # pop until common prefix
+  for i in [scopeStack.length..0]
+    break if _.isEqual(scopeStack[0...i], desiredScopes[0...i])
+    html = popScope(scopeStack, html)
+
+  # push on top of common prefix until scopeStack is desiredScopes
+  for j in [i...desiredScopes.length]
+    html = pushScope(scopeStack, desiredScopes[j], html)
+
+  html
+
+module.exports =
+  highlightSync = (options = {}) ->
+    registry = atom.grammars
+    {fileContents, scopeName, lineDivs, editorDiv, wrapCode, editorDivTag, editorDivClass, nullScope} = options
+    lineDivs ?= false
+    editorDiv ?= false
+    wrapCode ?= false
+    editorDivTag ?= 'div'
+    editorDivClass ?= 'editor editor-colors'
+    nullScope ?= 'text.plain.null-grammar'
+
+    grammar = registry.grammarForScopeName(scopeName) ? (registry.grammarForScopeName(nullScope) if nullScope)
+
+    throw new Error("Grammar #{scopeName} not found, and no #{nullScope} grammar") unless grammar?
+
+    lineTokens = grammar.tokenizeLines fileContents
+
+    # Remove trailing newline
+    if lineTokens.length > 0
+      lastLineTokens = lineTokens[lineTokens.length - 1]
+
+      if lastLineTokens.length is 1 and lastLineTokens[0].value is ''
+        lineTokens.pop()
+
+    html = ''
+    html = "<#{editorDivTag} class=\"#{editorDivClass}\">" if editorDiv
+    html += "<code>" if wrapCode
+    for tokens in lineTokens
+      scopeStack = []
+      html += '<div class="line">' if lineDivs
+      for {value, scopes} in tokens
+        value = ' ' unless value
+        scopes = scopes.map (scope) -> "syntax--#{scope.replace(/\./g, '.syntax--')}"
+        html = updateScopeStack scopeStack, scopes, html
+        html += "<span>#{value}</span>"
+      html = popScope(scopeStack, html) while scopeStack.length > 0
+      html += '\n'
+      html += '</div>' if lineDivs
+    html += "</code>" if wrapCode
+    html += "</#{editorDivTag}>" if editorDiv
+    html

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -3,7 +3,7 @@
 path = require 'path'
 fs = require 'fs-plus'
 cheerio = require 'cheerio'
-highlight = require 'atom-highlight'
+highlights = require './highlights'
 
 {scopeForFenceName} = require './highlights-helper'
 
@@ -135,10 +135,9 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
       if fenceName is defaultLanguage
         preElement.className = ''
       else
-        highlightedHtml = highlight
+        highlightedHtml = highlights
           fileContents: codeBlock.text()
           scopeName: scopeForFenceName(fenceName)
-          nbsp: true
           lineDivs: true
           editorDiv: true
           editorDivTag: 'pre'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -142,7 +142,7 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
           editorDiv: true
           editorDivTag: 'pre'
           # The `editor` class messes things up as `.editor` has absolutely positioned lines
-          editorDivClass: 'editor-colors'
+          editorDivClass: 'highlights editor-colors'
 
         highlightedBlock = $(highlightedHtml)
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -3,15 +3,7 @@
 path = require 'path'
 fs = require 'fs-plus'
 cheerio = require 'cheerio'
-
-# No direct dependence with Highlight because it requires a compilation. See #63 and #150 and atom/highlights#36.
-markdownPreviewPath = atom.packages.resolvePackagePath 'markdown-preview'
-commonHighlightsPath = path.join markdownPreviewPath, '..', 'highlights'
-if fs.isDirectorySync commonHighlightsPath
-  Highlights = require commonHighlightsPath
-else
-  # Fix specific problem with RPM made for Fedora by the Fedora community. See #226.
-  Highlights = require path.join markdownPreviewPath, 'node_modules', 'highlights'
+highlight = require 'atom-highlight'
 
 {scopeForFenceName} = require './highlights-helper'
 
@@ -143,14 +135,19 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
       if fenceName is defaultLanguage
         preElement.className = ''
       else
-        highlighter ?= new Highlights(registry: atom.grammars)
-        highlightedHtml = highlighter.highlightSync
+        highlightedHtml = highlight
           fileContents: codeBlock.text()
           scopeName: scopeForFenceName(fenceName)
+          nbsp: true
+          lineDivs: true
+          editorDiv: true
+          editorDivTag: 'pre'
+          # The `editor` class messes things up as `.editor` has absolutely positioned lines
+          editorDivClass: 'editor-colors'
 
         highlightedBlock = $(highlightedHtml)
-        # The `editor` class messes things up as `.editor` has absolutely positioned lines
-        highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
+
+        highlightedBlock.addClass("lang-#{fenceName}")
         highlightedBlock.insertAfter(preElement)
         preElement.remove()
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "asciidoc-preview"
   ],
   "engines": {
-    "atom": ">=1.9.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   },
   "dependencies": {
     "asciidoctor.js": "1.5.5-1",
@@ -25,8 +25,7 @@
     "fs-plus": "~2.9.3",
     "mustache": "~2.3.0",
     "opn": "^4.0.2",
-    "underscore-plus": "~1.6.6",
-    "atom-highlight": "^0.3.0"
+    "underscore-plus": "~1.6.6"
   },
   "devDependencies": {
     "coffeelint": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "fs-plus": "~2.9.3",
     "mustache": "~2.3.0",
     "opn": "^4.0.2",
-    "underscore-plus": "~1.6.6"
+    "underscore-plus": "~1.6.6",
+    "atom-highlight": "^0.3.0"
   },
   "devDependencies": {
     "coffeelint": "^1.15.0"

--- a/styles/asciidoc-preview.less
+++ b/styles/asciidoc-preview.less
@@ -84,9 +84,14 @@
     font-size: 1.0625em;
   }
 
-  pre.atom-text-editor {
-    background: @syntax-background-color !important;
-    border: 1px solid darken(@syntax-background-color, 10%) !important;
+  .listingblock pre.highlights {
+    background: contrast(@syntax-background-color, lighten(@syntax-background-color, 4%), darken(@syntax-background-color, 4%));
+  }
+
+  pre.highlights {
+    // background: contrast(@syntax-background-color, lighten(@syntax-background-color, 4%), darken(@syntax-background-color, 4%)) !important;
+    color: @syntax-text-color;
+    word-break: break-word;
   }
 
   .verseblock,


### PR DESCRIPTION
## Description

Atom CSS parsing changes broke the source highlighting in the preview pane.

Use the same approach than [markdown-preview-plus](https://github.com/atom-community/markdown-preview-plus/blob/master/lib/renderer.coffee).

See https://github.com/atom-haskell/atom-highlights.

## Syntax example

```adoc
[source, js]
----
var http = require('http');
http.createServer(function (req, res) {
  res.end('Hello World\n');
}).listen(1337, '127.0.0.1');
----
```

## Screenshots

![capture du 2017-04-02 01-38-14](https://cloud.githubusercontent.com/assets/5674651/24583274/19a45908-1745-11e7-8232-72b8be27696a.png)

Fix #229 
