### PR TITLE
Highlighted source block should respect syntax theme

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -3,15 +3,7 @@
 path = require 'path'
 fs = require 'fs-plus'
 cheerio = require 'cheerio'
-
-# No direct dependence with Highlight because it requires a compilation. See #63 and #150 and atom/highlights#36.
-markdownPreviewPath = atom.packages.resolvePackagePath 'markdown-preview'
-commonHighlightsPath = path.join markdownPreviewPath, '..', 'highlights'
-if fs.isDirectorySync commonHighlightsPath
-  Highlights = require commonHighlightsPath
-else
-  # Fix specific problem with RPM made for Fedora by the Fedora community. See #226.
-  Highlights = require path.join markdownPreviewPath, 'node_modules', 'highlights'
+highlight = require 'atom-highlight'
 
 {scopeForFenceName} = require './highlights-helper'
 
@@ -143,14 +135,19 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
       if fenceName is defaultLanguage
         preElement.className = ''
       else
-        highlighter ?= new Highlights(registry: atom.grammars)
-        highlightedHtml = highlighter.highlightSync
+        highlightedHtml = highlight
           fileContents: codeBlock.text()
           scopeName: scopeForFenceName(fenceName)
+          nbsp: true
+          lineDivs: true
+          editorDiv: true
+          editorDivTag: 'pre'
+          # The `editor` class messes things up as `.editor` has absolutely positioned lines
+          editorDivClass: 'editor-colors'
 
         highlightedBlock = $(highlightedHtml)
-        # The `editor` class messes things up as `.editor` has absolutely positioned lines
-        highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
+
+        highlightedBlock.addClass("lang-#{fenceName}")
         highlightedBlock.insertAfter(preElement)
         preElement.remove()
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -143,7 +143,7 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
           editorDiv: true
           editorDivTag: 'pre'
           # The `editor` class messes things up as `.editor` has absolutely positioned lines
-          editorDivClass: 'editor-colors'
+          editorDivClass: 'highlights editor-colors'
 
         highlightedBlock = $(highlightedHtml)
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "fs-plus": "~2.9.3",
     "mustache": "~2.3.0",
     "opn": "^4.0.2",
-    "underscore-plus": "~1.6.6"
+    "underscore-plus": "~1.6.6",
+    "atom-highlight": "^0.3.0"
   },
   "devDependencies": {
     "coffeelint": "^1.15.0"

--- a/styles/asciidoc-preview.less
+++ b/styles/asciidoc-preview.less
@@ -84,9 +84,10 @@
     font-size: 1.0625em;
   }
 
-  pre.atom-text-editor {
-    background: @syntax-background-color !important;
-    border: 1px solid darken(@syntax-background-color, 10%) !important;
+  pre.highlights {
+    background: contrast(@syntax-background-color, lighten(@syntax-background-color, 4%), darken(@syntax-background-color, 4%)) !important;
+    color: @syntax-text-color;
+    word-break: break-word;
   }
 
   .verseblock,


### PR DESCRIPTION
## Description

This patch updates the stylesheet to apply the syntax variables correctly to a highlighted source block so it respects the syntax theme in the same way as the markdown-preview. It also reverts the word-break setting, which is inconsistent with how the editor works.

## Syntax example

```adoc
[source,ruby]
----
require 'asciidoctor/extensions'

Asciidoctor::Extensions.register do
  treeprocessor do
    process do |doc|
      (doc.find_by context: :dlist).each do |dlist|
        dlist.style = 'horizontal'
      end
      nil
    end
  end
end
----
```

## Screenshots

![source-block-syntax-theme](https://cloud.githubusercontent.com/assets/79351/24585601/5381d928-174c-11e7-9d20-611bc9f260ff.png)

Fix #231