### PR TITLE
Don't force scrolling on the x axis

### DIFF
--- a/styles/asciidoc-preview.less
+++ b/styles/asciidoc-preview.less
@@ -15,7 +15,8 @@
   font-size: 16px;
   line-height: 1.6;
   background-color: #fff;
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: auto;
   box-sizing: border-box;
   padding: 20px;
   color: rgba(0,0,0,.8);


### PR DESCRIPTION
## Description

Set the overflow on the y axis to `scroll`, but set the overflow on the x axis to `auto`.

## Syntax example

```adoc
[source,ruby]
----
require 'asciidoctor/extensions'

Asciidoctor::Extensions.register do
  treeprocessor do
    process do |doc|
      (doc.find_by context: :dlist).each do |dlist|
        dlist.style = 'horizontal'
      end
      nil
    end
  end
end
----

oh

here

it

goes

again
```

## Screenshots

![overflow-scroll-auto](https://cloud.githubusercontent.com/assets/79351/24585726/c244e9de-174e-11e7-9522-4c388808295f.png)

Fix #233 