### PR TITLE
Save as HTML with Atom 1.24.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "asciidoc-preview"
   ],
   "engines": {
-    "atom": ">=1.13.0 <2.0.0"
+    "atom": ">=1.24.0 <2.0.0"
   },
   "dependencies": {
     "asciidoctor.js": "1.5.5-1",


### PR DESCRIPTION
## Description

Save as HTML with Atom 1.24.

Due to https://github.com/atom/atom/pull/16245.

Fixes #258

cc @kachkaev