### PR TITLE
Allow highlight for PHP even without <?php

### DIFF
--- a/lib/highlights-helper.coffee
+++ b/lib/highlights-helper.coffee
@@ -73,6 +73,6 @@ module.exports =
   scopeForFenceName: (fenceName, useSource = false) ->
     fenceName = fenceName.toLowerCase()
     if useSource
-        "source.#{fenceName}"
+      "source.#{fenceName}"
     else
-        scopesByFenceName[fenceName] ? "source.#{fenceName}"
+      scopesByFenceName[fenceName] ? "source.#{fenceName}"

--- a/lib/highlights-helper.coffee
+++ b/lib/highlights-helper.coffee
@@ -70,6 +70,9 @@ scopesByFenceName =
   'ts': 'source.ts'
 
 module.exports =
-  scopeForFenceName: (fenceName) ->
+  scopeForFenceName: (fenceName, useSource = false) ->
     fenceName = fenceName.toLowerCase()
-    scopesByFenceName[fenceName] ? "source.#{fenceName}"
+    if useSource
+        "source.#{fenceName}"
+    else
+        scopesByFenceName[fenceName] ? "source.#{fenceName}"

--- a/lib/highlights-helper.coffee
+++ b/lib/highlights-helper.coffee
@@ -70,9 +70,9 @@ scopesByFenceName =
   'ts': 'source.ts'
 
 module.exports =
-  scopeForFenceName: (fenceName, useSource = false) ->
+  scopeForFenceName: (fenceName, blockText) ->
     fenceName = fenceName.toLowerCase()
-    if useSource
+    if fenceName is 'php' and not blockText.startsWith '<?php'
       "source.#{fenceName}"
     else
       scopesByFenceName[fenceName] ? "source.#{fenceName}"

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -135,14 +135,10 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
       if fenceName is defaultLanguage
         preElement.className = ''
       else
-        code = codeBlock.text()
-        useSource = false
-        if fenceName is 'php' and not /<\?(php|=)/.test(code)
-          useSource = true
-
+        blockText = codeBlock.text()
         highlightedHtml = highlights
-          fileContents: code
-          scopeName: scopeForFenceName(fenceName, useSource)
+          fileContents: blockText
+          scopeName: scopeForFenceName(fenceName, blockText)
           lineDivs: true
           editorDiv: true
           editorDivTag: 'pre'

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -135,28 +135,21 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
       if fenceName is defaultLanguage
         preElement.className = ''
       else
-        # highlight php even without <?php by adding a temporary one
         code = codeBlock.text()
-        added_php_starter = false
+        useSource = false
         if fenceName is 'php' and not /<\?(php|=)/.test(code)
-          code = "<?php\n" + code
-          added_php_starter = true
+          useSource = true
 
         highlightedHtml = highlights
           fileContents: code
-          scopeName: scopeForFenceName(fenceName)
+          scopeName: scopeForFenceName(fenceName, useSource)
           lineDivs: true
           editorDiv: true
           editorDivTag: 'pre'
           # The `editor` class messes things up as `.editor` has absolutely positioned lines
           editorDivClass: 'highlights editor-colors'
 
-        if added_php_starter is true
-          highlightedBlock = $(highlightedHtml)
-          # remove temporarily added <?php
-          highlightedBlock.find('div.line:first').remove()
-        else
-          highlightedBlock = $(highlightedHtml)
+        highlightedBlock = $(highlightedHtml)
 
         highlightedBlock.addClass("lang-#{fenceName}")
         highlightedBlock.insertAfter(preElement)

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -135,8 +135,15 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
       if fenceName is defaultLanguage
         preElement.className = ''
       else
+        # highlight php even without <?php by adding a temporary one
+        code = codeBlock.text()
+        added_php_starter = false
+        if fenceName == 'php' && ! /<\?(php|=)/.test(code)
+          code = "<?php\n" + code
+          added_php_starter = true
+
         highlightedHtml = highlights
-          fileContents: codeBlock.text()
+          fileContents: code
           scopeName: scopeForFenceName(fenceName)
           lineDivs: true
           editorDiv: true
@@ -144,7 +151,12 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
           # The `editor` class messes things up as `.editor` has absolutely positioned lines
           editorDivClass: 'highlights editor-colors'
 
-        highlightedBlock = $(highlightedHtml)
+        if added_php_starter == true
+          highlightedBlock = $(highlightedHtml);
+          # remove temporarily added <?php
+          highlightedBlock.find('div.line:first').remove()
+        else
+          highlightedBlock = $(highlightedHtml)
 
         highlightedBlock.addClass("lang-#{fenceName}")
         highlightedBlock.insertAfter(preElement)

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -138,7 +138,7 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
         # highlight php even without <?php by adding a temporary one
         code = codeBlock.text()
         added_php_starter = false
-        if fenceName == 'php' && ! /<\?(php|=)/.test(code)
+        if fenceName is 'php' and not /<\?(php|=)/.test(code)
           code = "<?php\n" + code
           added_php_starter = true
 
@@ -151,7 +151,7 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
           # The `editor` class messes things up as `.editor` has absolutely positioned lines
           editorDivClass: 'highlights editor-colors'
 
-        if added_php_starter == true
+        if added_php_starter is true
           highlightedBlock = $(highlightedHtml);
           # remove temporarily added <?php
           highlightedBlock.find('div.line:first').remove()

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -152,7 +152,7 @@ tokenizeCodeBlocks = (html, defaultLanguage='text') ->
           editorDivClass: 'highlights editor-colors'
 
         if added_php_starter is true
-          highlightedBlock = $(highlightedHtml);
+          highlightedBlock = $(highlightedHtml)
           # remove temporarily added <?php
           highlightedBlock.find('div.line:first').remove()
         else


### PR DESCRIPTION
## Description

Allow highlight for PHP even without starting <?php.

## Syntax example

```adoc
[source,php]
----
echo "highlight me please";
----
```

## Screenshots

![screenshot from 2018-04-10 22-03-00](https://user-images.githubusercontent.com/1734126/38561584-fc5ef2a8-3d0a-11e8-951d-a6a1913eab9e.png)
