### PR TITLE
Use safe ID lookup

### DIFF
--- a/lib/asciidoc-preview-view.coffee
+++ b/lib/asciidoc-preview-view.coffee
@@ -115,7 +115,7 @@ class AsciiDocPreviewView extends ScrollView
       if atom.config.get 'asciidoc-preview.scrollMode'
         blockId = renderer.getBlockId event.newBufferPosition.row
         if blockId?
-          if target = $('#' + blockId)[0]
+          if target = document.getElementById(blockId)
             callback target.offsetTop
         # else
           # TODO Find the nearest block


### PR DESCRIPTION
- use document.getElementById('ID') instead of $('#ID')

Fixes #276