### PR TITLE
Update the readme with the :toc: left thingy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ More options are available :
 * by right-clicking on the preview
 * by right-clicking on an AsciiDoc file.
 
+#### Notes
+* Attributes that has no direct influence on the contents (for example: `:toc: left`) are not respected. This is by design. The preview window is not meant to emulate the webpage that the end user sees, it's meant to offer a preview of the content.
+
 ## Others Atom packages for AsciiDoc
 
 * [language-asciidoc](https://atom.io/packages/language-asciidoc): Syntax highlighting and snippets for AsciiDoc (with Asciidoctor flavor).

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ More options are available :
 * by right-clicking on the preview
 * by right-clicking on an AsciiDoc file.
 
-#### Notes
-* Attributes that has no direct influence on the contents (for example: `:toc: left`) are not respected. This is by design. The preview window is not meant to emulate the webpage that the end user sees, it's meant to offer a preview of the content.
+#### Disclaimer
+* The preview window is not meant to emulate the final HTML that the end user sees, it's meant to offer only a preview of the content. This is by design (one of the reasons is due to a limited screen space).
 
 ## Others Atom packages for AsciiDoc
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ More options are available :
 
 ## Disclaimer About Styles
 
-The preview window is not meant to emulate the published styles. Rather, it's intended to present a preview of the content to assist with editing. This is by design. It also aims to make the best use of limited screen space. So, for example, you won't see functionality such as a sidebar TOC. The colors may also differ to better integrate with the Atom theme. If you want to customize the apparance of the preview, you can specify your own stylesheet in the settings.
+The preview window is not meant to emulate the published styles.
+Rather, it's intended to present a preview of the content to assist with editing.
+This is by design.
+It also aims to make the best use of limited screen space.
+So, for example, you won't see functionality such as a sidebar TOC.
+The colors may also differ to better integrate with the Atom theme.
+If you want to customize the apparance of the preview, you can specify your own stylesheet in the settings.
 
 ## Others Atom packages for AsciiDoc
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ More options are available :
 
 ## Disclaimer About Styles
 
-The preview window is not meant to emulate the published styles. Rather, it's intended to present a preview of the content to assist with editing. This is by design. It also aims to make the best use of limited screen space. So, for example, you won't see functionality such as a sidebar TOC. The colors may also differ to better integrate with the Atom theme.
+The preview window is not meant to emulate the published styles. Rather, it's intended to present a preview of the content to assist with editing. This is by design. It also aims to make the best use of limited screen space. So, for example, you won't see functionality such as a sidebar TOC. The colors may also differ to better integrate with the Atom theme. If you want to customize the apparance of the preview, you can specify your own stylesheet in the settings.
 
 ## Others Atom packages for AsciiDoc
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ More options are available :
 * by right-clicking on the preview
 * by right-clicking on an AsciiDoc file.
 
-#### Disclaimer
-* The preview window is not meant to emulate the final HTML that the end user sees, it's meant to offer only a preview of the content. This is by design (one of the reasons is due to a limited screen space).
+## Disclaimer About Styles
+
+The preview window is not meant to emulate the published styles. Rather, it's intended to present a preview of the content to assist with editing. This is by design. It also aims to make the best use of limited screen space. So, for example, you won't see functionality such as a sidebar TOC. The colors may also differ to better integrate with the Atom theme.
 
 ## Others Atom packages for AsciiDoc
 


### PR DESCRIPTION
Following the discussion [here](https://github.com/asciidoctor/atom-asciidoc-preview/issues/282), I am proposing this change in the README.