### PR TITLE
Sunsetting Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+### :information_source: **Information** :information_source:
+
+[GitHub is sunsetting Atom on December 15, 2022](https://github.blog/2022-06-08-sunsetting-atom/).   
+As a result, we recommend migrating to an alternative solution. The Asciidoctor community is now focusing on providing the best writing experience using the [IntelliJ platform](https://github.com/asciidoctor/asciidoctor-intellij-plugin) or [Visual Studio Code](https://github.com/asciidoctor/asciidoctor-vscode).
+
+On December 15, 2022, this repository will be archived.
+
+---
+
 # AsciiDoc Preview package
 
 [![Atom Package](https://img.shields.io/apm/v/asciidoc-preview.svg)](https://atom.io/packages/asciidoc-preview)


### PR DESCRIPTION
[GitHub is sunsetting Atom on December 15, 2022](https://github.blog/2022-06-08-sunsetting-atom/) 

Thanks to [all contributors](https://github.com/asciidoctor/atom-asciidoc-preview/graphs/contributors) ❤️, it's time to move on 🥲 